### PR TITLE
Adding a badge for the Open Source Security Foundation (OpenSSF) Best Practices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,8 @@ FIREWHEEL
     :target: https://pypi.org/project/firewheel/
 .. image:: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg
     :target: https://sandialabs.github.io/firewheel/developer/code_of_conduct.html
+.. image:: https://www.bestpractices.dev/projects/9722/badge
+   :target: https://www.bestpractices.dev/projects/9722
 
 .. readme-inclusion-marker
 

--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,10 @@ FIREWHEEL
 
 .. image:: https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%7C%203.11%7C%203.12%7C%203.13-blue
     :target: https://pypi.org/project/firewheel/
-.. image:: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg
-    :target: https://sandialabs.github.io/firewheel/developer/code_of_conduct.html
 .. image:: https://www.bestpractices.dev/projects/9722/badge
    :target: https://www.bestpractices.dev/projects/9722
+.. image:: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg
+    :target: https://sandialabs.github.io/firewheel/developer/code_of_conduct.html
 
 .. readme-inclusion-marker
 


### PR DESCRIPTION
> The [Open Source Security Foundation (OpenSSF)](https://openssf.org/) Best Practices badge is a way for Free/Libre and Open Source Software (FLOSS) projects to show that they follow best practices. Projects can voluntarily self-certify, at no cost, by using this web application to explain how they follow each best practice. The OpenSSF Best Practices Badge is inspired by the many badges available to projects on GitHub. Consumers of the badge can quickly assess which FLOSS projects are following best practices and as a result are more likely to produce higher-quality secure software.

This PR completed the initial assessment for FIREWHEEL and adds the corresponding badge. 