### PR TITLE
Using built-in tools to automatically version FIREWHEEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* Using built-in tools to automatically version FIREWHEEL.
+* Adding the horizontal logo for FIREWHEEL to the README.
+* Fixing the license appearance on PyPI.
+* Fixing a few references to GitLab that should be GitHub.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-* Using built-in tools to automatically version FIREWHEEL.
-* Adding the horizontal logo for FIREWHEEL to the README.
-* Fixing the license appearance on PyPI.
-* Fixing a few references to GitLab that should be GitHub.
 
 ### Deprecated
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,9 +116,6 @@ get_fw_tab_completion_script = "firewheel.cli.completion.prepare_completion_scri
 # Required for tox documentation building
 firewheel = ["firewheel.yaml"]
 
-[tool.setuptools.dynamic]
-version = {attr = "firewheel.__version__"}
-
 [tool.setuptools_scm]
 
 [tool.doc8]

--- a/src/firewheel/__init__.py
+++ b/src/firewheel/__init__.py
@@ -1,5 +1,3 @@
 from pathlib import Path
 
-__version__ = "2.7.0"
-
 FIREWHEEL_PACKAGE_DIR = Path(__file__).parent

--- a/src/firewheel/cli/firewheel_cli.py
+++ b/src/firewheel/cli/firewheel_cli.py
@@ -13,7 +13,6 @@ from rich.columns import Columns
 from rich.console import Console
 from rich.markdown import Markdown
 
-import firewheel
 from firewheel.cli import utils
 from firewheel.config import Config
 from firewheel.lib.log import Log

--- a/src/firewheel/cli/firewheel_cli.py
+++ b/src/firewheel/cli/firewheel_cli.py
@@ -7,6 +7,7 @@ import logging
 import textwrap
 from math import floor
 from uuid import uuid4
+from importlib.metadata import version
 
 from rich.columns import Columns
 from rich.console import Console
@@ -953,7 +954,7 @@ see :ref:`cli_helper_section`."""
         # Write to the history file.
         if not self.interactive:
             self.write_history(f"version {arg}")
-        print(firewheel.__version__)
+        print(version("firewheel"))
 
     def help_list(self):
         """Help message for the list command.

--- a/src/firewheel/lib/grpc/firewheel_grpc_server.py
+++ b/src/firewheel/lib/grpc/firewheel_grpc_server.py
@@ -11,7 +11,6 @@ from importlib.metadata import version
 import grpc
 from google.protobuf.json_format import Parse, MessageToDict
 
-import firewheel
 from firewheel.config import Config
 from firewheel.lib.log import Log
 from firewheel.lib.grpc import firewheel_grpc_pb2, firewheel_grpc_pb2_grpc

--- a/src/firewheel/lib/grpc/firewheel_grpc_server.py
+++ b/src/firewheel/lib/grpc/firewheel_grpc_server.py
@@ -6,6 +6,7 @@ import contextlib
 from typing import Iterable
 from datetime import datetime
 from concurrent import futures
+from importlib.metadata import version
 
 import grpc
 from google.protobuf.json_format import Parse, MessageToDict
@@ -52,7 +53,7 @@ class FirewheelServicer(firewheel_grpc_pb2_grpc.FirewheelServicer):
 
         self.log.info("Initialized FirewheelServicer log.")
         self.server_start_time = datetime.utcnow()
-        self.version = firewheel.__version__
+        self.version = version("firewheel")
         self.cache_dir = os.path.join(
             config["grpc"]["root_dir"], config["grpc"]["cache_dir"]
         )

--- a/src/firewheel/tests/unit/cli/test_cli.py
+++ b/src/firewheel/tests/unit/cli/test_cli.py
@@ -7,7 +7,6 @@ import unittest
 import unittest.mock
 from importlib.metadata import version
 
-import firewheel
 from firewheel.config import Config
 from firewheel.cli.utils import HelperNotFoundError
 from firewheel.cli.firewheel_cli import FirewheelCLI

--- a/src/firewheel/tests/unit/cli/test_cli.py
+++ b/src/firewheel/tests/unit/cli/test_cli.py
@@ -5,6 +5,7 @@ import uuid
 import tempfile
 import unittest
 import unittest.mock
+from importlib.metadata import version
 
 import firewheel
 from firewheel.config import Config
@@ -277,7 +278,7 @@ class CliTestCase(unittest.TestCase):
         args = ""
         cli.do_version(args)
 
-        self.assertEqual(mock_stdout.getvalue().strip(), firewheel.__version__)
+        self.assertEqual(mock_stdout.getvalue().strip(), version("firewheel"))
 
     def test_do_exit(self):
         cli = FirewheelCLI()


### PR DESCRIPTION
This PR moves away from manually defined versioning to using [setuptools-scm](https://setuptools-scm.readthedocs.io/en/latest/) and our GitHub releases to version the software.