### PR TITLE
Adding the model component documentation once it becomes available.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,8 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+  pull_request:
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -25,9 +27,7 @@ concurrency:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -51,11 +51,12 @@ jobs:
 
   # Deployment job
   deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'  # Only run on pushes to main
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,11 +13,10 @@
 import sys
 import importlib.util
 from pathlib import Path
-from importlib.metadata import metadata
+from importlib.metadata import metadata, version
 
 import sphinx_rtd_theme  # noqa: F401
 
-import firewheel
 from firewheel.control.repository_db import RepositoryDb
 from firewheel.control.model_component_manager import ModelComponentManager
 from firewheel.control.model_component_iterator import ModelComponentIterator
@@ -33,10 +32,10 @@ project_copyright = (
 author = "Sandia National Laboratories"
 
 # The short X.Y version
-version = firewheel.__version__
+version = version("firewheel")
 
 # The full version, including alpha/beta/rc tags
-release = firewheel.__version__
+release = version("firewheel")
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,8 @@
 import sys
 import importlib.util
 from pathlib import Path
-from importlib.metadata import metadata, version
+from importlib.metadata import version as importlib_version
+from importlib.metadata import metadata
 
 import sphinx_rtd_theme  # noqa: F401
 
@@ -32,10 +33,10 @@ project_copyright = (
 author = "Sandia National Laboratories"
 
 # The short X.Y version
-version = version("firewheel")
+version = importlib_version("firewheel")
 
 # The full version, including alpha/beta/rc tags
-release = version("firewheel")
+release = importlib_version("firewheel")
 
 
 # -- General configuration ---------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -117,9 +117,13 @@ commands =
 basepython = python3
 changedir={toxinidir}/docs
 extras = docs
+deps =
+    firewheel-repo-base
 allowlist_externals=
     /usr/bin/make
+    /bin/mkdir
 commands =
+    mkdir -p source/model_components
     make html
     all: make singlehtml
     all: sphinx-build -M man source/cli build -c source

--- a/tox.ini
+++ b/tox.ini
@@ -120,6 +120,7 @@ extras = docs
 deps =
     firewheel-repo-base
     firewheel-repo-linux
+    firewheel-repo-vyos
     firewheel-repo-tutorials
     firewheel-repo-layer2
     firewheel-repo-ntp

--- a/tox.ini
+++ b/tox.ini
@@ -119,6 +119,11 @@ changedir={toxinidir}/docs
 extras = docs
 deps =
     firewheel-repo-base
+    firewheel-repo-linux
+    firewheel-repo-tutorials
+    firewheel-repo-layer2
+    firewheel-repo-ntp
+    firewheel-repo-dns
 allowlist_externals=
     /usr/bin/make
     /bin/mkdir

--- a/tox.ini
+++ b/tox.ini
@@ -123,8 +123,8 @@ allowlist_externals=
     /usr/bin/make
     /bin/mkdir
 commands =
-    mkdir -p source/model_components
-    make html
+    /bin/mkdir -p source/model_components
+    /usr/bin/make html
     all: make singlehtml
     all: sphinx-build -M man source/cli build -c source
     all: make latexpdf


### PR DESCRIPTION
This PR adds the newly released documentation for officially supported model components and enables previewing the documentation prior to merging as we now always build the docs, but will only release them when the PR has been merged.

As of this PR the documentation includes:
* [firewheel_repo_base](https://github.com/sandialabs/firewheel_repo_base)
* [firewheel_repo_tutorials](https://github.com/sandialabs/firewheel_repo_tutorials)
* [firewheel_repo_ntp](https://github.com/sandialabs/firewheel_repo_ntp)
* [firewheel_repo_linux](https://github.com/sandialabs/firewheel_repo_linux)
* [firewheel_repo_vyos](https://github.com/sandialabs/firewheel_repo_vyos)
* [firewheel_repo_layer2](https://github.com/sandialabs/firewheel_repo_layer2)
* [firewheel_repo_dns](https://github.com/sandialabs/firewheel_repo_dns)