### PR TITLE
Allow workflow reuse across the FIREWHEEL ecosystem

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,6 +8,8 @@ on:
     branches: [ "*" ]
   pull_request:
     branches: [ "main" ]
+  # Allow reuse across the FIREWHEEL ecosystem
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,8 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  # Allow reuse across the FIREWHEEL ecosystem
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
This adds the `workflow_call` keyword to the current workflows, enabling the workflows to be used as [reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows). This will allow us to essentially import the standard FIREWHEEL workflows in our model component repositories (see sandialabs/firewheel_repo_base#1).