### PR TITLE
Removing outdated references to Elasticsearch

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,11 +13,11 @@
 import sys
 import importlib.util
 from pathlib import Path
+from importlib.metadata import version as importlib_version
 from importlib.metadata import metadata
 
 import sphinx_rtd_theme  # noqa: F401
 
-import firewheel
 from firewheel.control.repository_db import RepositoryDb
 from firewheel.control.model_component_manager import ModelComponentManager
 from firewheel.control.model_component_iterator import ModelComponentIterator
@@ -33,10 +33,10 @@ project_copyright = (
 author = "Sandia National Laboratories"
 
 # The short X.Y version
-version = firewheel.__version__
+version = importlib_version("firewheel")
 
 # The full version, including alpha/beta/rc tags
-release = firewheel.__version__
+release = importlib_version("firewheel")
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/system/architecture.rst
+++ b/docs/source/system/architecture.rst
@@ -98,8 +98,6 @@ Once the *VM Resource Manager* has successfully finished monitoring and managing
 Analytics
 ---------
 
-Once the experiment is launched, it is important to gather and analyze experimental data.
-To assist with this task, FIREWHEEL installs Elasticsearch, Logstash, and Kibana, more commonly known as an ELK stack.
-Data from VM Resources can be ingested into ELK by printing to Standard Output (`stdout`).
-To make greater use of the ELK stack, VM Resources can also print to `stdout` in JSON format which will be added to Elasticsearch.
-Once the data has been ingested, users can use Kibana to create dashboards which visually display experimental data.
+Once the experiment is launched, gathering and analyzing experimental data becomes crucial.
+To facilitate this process, FIREWHEEL provides seamless logging of VM resource output and generates JSON-formatted logs that can be easily ingested into data analysis tools such as Elasticsearch or Jupyter Notebooks.
+After the data has been ingested into your preferred tool, users can visually display the experimental data or conduct analyses as needed.

--- a/src/firewheel/__init__.py
+++ b/src/firewheel/__init__.py
@@ -1,3 +1,6 @@
 from pathlib import Path
+from importlib.metadata import version
+
+__version__ = version("firewheel")
 
 FIREWHEEL_PACKAGE_DIR = Path(__file__).parent


### PR DESCRIPTION
This PR updates the documentation to fix an outdated comment that Elasticsearch is installed with FIREWHEEL. Additionally, we fix a bug introduced by #14 which neglected to update the version for the Sphinx documentation.