### PR TITLE
Enabling the passing of the PYPI token to this workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,6 +13,9 @@ on:
     types: [published]
   # Allow reuse across the FIREWHEEL ecosystem
   workflow_call:
+    secrets:
+      PYPI_API_TOKEN:
+        required: true
 
 permissions:
   contents: read


### PR DESCRIPTION
This allows model component repositories to pass their own PYPI secret to the package publishing workflow.