### PR TITLE
Addressing a deprecated assumption from NetworkX "links" data. S…

### DIFF
--- a/src/firewheel/control/dependency_graph.py
+++ b/src/firewheel/control/dependency_graph.py
@@ -219,7 +219,7 @@ class DependencyGraph:
                     {"id": <id>, "type": <"entity" or "constraint">},
                     ...
                 ],
-                "links": [
+                "edges": [
                     {"source": <id>, "target": <id>},
                     ...
                 ],
@@ -228,13 +228,13 @@ class DependencyGraph:
                 "multigraph": False
             }
         """
-        data = json_graph.node_link_data(self.dg)
+        data = json_graph.node_link_data(self.dg, edges="edges")
 
         nodes = {}
         for node in data["nodes"]:
             nodes[node["id"]] = node
 
-        for edge in data["links"]:
+        for edge in data["edges"]:
             edge["source"] = nodes[edge["source"]]["id"]
             edge["target"] = nodes[edge["target"]]["id"]
 


### PR DESCRIPTION
The "link" keyword is deprecated for the `node_link_data` function and will be removed in version  NetworkX v3.6. We are switching to the recommended default "edges" instead.

See [node-link-data](https://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.json_graph.node_link_data.html#node-link-data) for more details.