### PR TITLE
Update documentation with minor changes

### DIFF
--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -91,7 +91,7 @@ A full list of environment variables used in ``install.sh`` is shown below.
 
 .. envvar:: PYTHON_BIN
 
-    :description: The path to the Python interpreter.
+    :description: The Python interpreter executable (a path or symlink).
     :default: ``python3``
 
 .. envvar:: PIP_ARGS

--- a/docs/source/install/prereqs.rst
+++ b/docs/source/install/prereqs.rst
@@ -25,7 +25,7 @@ The following command will install all required system packages for FIREWHEEL an
 
 For users who are improving FIREWHEEL, building documentation, or running the FIREWHEEL tests, these packages are also needed::
 
-    sudo apt-get install -y graphviz texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk libenchant-dev
+    sudo apt-get install -y graphviz texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk libenchant-2-dev
 
 CentOS
 ------

--- a/docs/source/install/prereqs.rst
+++ b/docs/source/install/prereqs.rst
@@ -13,7 +13,7 @@ System Dependencies
    :start-after: dependencies-inclusion-marker
    :end-before: dependencies-inclusion-stop
 
-This section quickly outlines the system packages needed for full FIREWHEEL functionality with the exception of Python, discovery, minimega, git, and git-lfs as those are discussed in detail below.
+Below is a brief outline of the system packages needed for full FIREWHEEL functionality with the exception of Python, discovery, minimega, git, and git-lfs as those are discussed in further detail in subsequent sections.
 
 Full details about FIREWHEEL's dependencies be found in :ref:`firewheel-dependencies`.
 

--- a/docs/source/install/prereqs/dependencies.rst
+++ b/docs/source/install/prereqs/dependencies.rst
@@ -86,8 +86,8 @@ Optional System Packages (for Developers)
     + Ubuntu Package(s): ``texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk``
 - Enchant:
     + Purpose: For checking documentation spelling.
-    + Ubuntu Package(s): ``libenchant-dev``
-    + CentOS Package(s): ``enchant-devel``
+    + Ubuntu Package(s): ``libenchant-2-dev``
+    + CentOS Package(s): ``enchant2-devel``
 
 Python Dependencies
 ===================

--- a/docs/source/install/prereqs/dependencies.rst
+++ b/docs/source/install/prereqs/dependencies.rst
@@ -10,12 +10,14 @@ System Dependencies
 While FIREWHEEL is a Python package, it also depends on several system-level packages.
 FIREWHEEL has been tested with the following operating systems:
 
-* Ubuntu 16.04
 * Ubuntu 18.04
 * Ubuntu 20.04
+* Ubuntu 22.04
 * CentOS 7
+* RHEL 8
+* RHEL 9
 
-However, the underlying system packages likely will work on all OSes.
+The instructions provided in this documentation are tailored specifically for Ubuntu 22.04 and RHEL 9, although FIREWHEEL will likely be compatible with corresponding system packages on the majority of operating systems.
 
 .. dependencies-inclusion-stop
 


### PR DESCRIPTION
This provides a few minor updates to the docs.

1. I clarify that the `PYTHON_BIN` environment variable is the executable (which may be either a path or a symlink). I think this wording might be better, because just giving `python3` (assuming that it's being run in a virtual environment) doesn't strike me as a path.
2. It appears that `libenchant-dev` has been superseded by `libenchant-2-dev` and is accessible with that new name in the relevant Ubuntu repositories. (Similar for Fedora-based OSs and `enchant2-devel` and `enchant-devel`.)