### PR TITLE
Add a get method to the Vertex object to simulate a dictionary

### DIFF
--- a/src/firewheel/control/experiment_graph.py
+++ b/src/firewheel/control/experiment_graph.py
@@ -721,6 +721,27 @@ class Vertex(ExperimentGraphDecorable):
         if name:
             self.name = name
 
+    def get(self, key, default=None):
+        """
+        Dictionary-style access to read :py:class:`Vertex` attributes.
+
+        Args:
+            key (str): A key to query.
+            default: The default value to return if the key is not found.
+
+        Returns:
+            The value of the requested attribute if the attribute is in
+            the set of available attributes, else ``default``. If
+            ``default`` is not given, it defaults to :py:data:`None`, so
+            that this method never raises a `KeyError`.
+
+        Raises:
+            RuntimeError: If the :py:class:`Vertex` is not :py:attr:`Vertex.valid`.
+        """
+        if not self.valid:
+            raise RuntimeError("Attempted operation on invalid Vertex instance.")
+        return self.g.g.nodes[self.graph_id].get(key, default=default)
+
     def get_object(self):
         """
         Get the :py:class:`Vertex` object attribute (i.e. ``self``).

--- a/src/firewheel/control/experiment_graph.py
+++ b/src/firewheel/control/experiment_graph.py
@@ -740,7 +740,7 @@ class Vertex(ExperimentGraphDecorable):
         """
         if not self.valid:
             raise RuntimeError("Attempted operation on invalid Vertex instance.")
-        return self.g.g.nodes[self.graph_id].get(key, default=default)
+        return self.g.g.nodes[self.graph_id].get(key, default)
 
     def get_object(self):
         """

--- a/src/firewheel/control/experiment_graph.py
+++ b/src/firewheel/control/experiment_graph.py
@@ -733,7 +733,7 @@ class Vertex(ExperimentGraphDecorable):
             The value of the requested attribute if the attribute is in
             the set of available attributes, else ``default``. If
             ``default`` is not given, it defaults to :py:data:`None`, so
-            that this method never raises a `KeyError`.
+            that this method never raises a :py:exc:`KeyError`.
 
         Raises:
             RuntimeError: If the :py:class:`Vertex` is not :py:attr:`Vertex.valid`.

--- a/src/firewheel/tests/unit/control/test_experiment_graph_vertex.py
+++ b/src/firewheel/tests/unit/control/test_experiment_graph_vertex.py
@@ -41,6 +41,17 @@ class ExperimentGraphVertexTestCase(unittest.TestCase):
             # pylint: disable=pointless-statement
             v["name"]
 
+    def test_get(self):
+        v = Vertex(self.g)
+        self.assertIsNone(v.get("name"))
+
+        v["name"] = "test"
+        self.assertEqual(v.get("name"), "test")
+
+    def test_get_alternate_default(self):
+        v = Vertex(self.g)
+        self.assertEqualNone(v.get("name", default="test"), "test")
+
     def test_has(self):
         v = Vertex(self.g)
         self.assertFalse("name" in v)

--- a/src/firewheel/tests/unit/control/test_experiment_graph_vertex.py
+++ b/src/firewheel/tests/unit/control/test_experiment_graph_vertex.py
@@ -50,7 +50,7 @@ class ExperimentGraphVertexTestCase(unittest.TestCase):
 
     def test_get_alternate_default(self):
         v = Vertex(self.g)
-        self.assertEqualNone(v.get("name", default="test"), "test")
+        self.assertEqual(v.get("name", default="test"), "test")
 
     def test_has(self):
         v = Vertex(self.g)


### PR DESCRIPTION
At least one model component [assumes that the `Vertex` object fully implements dictionary behavior](https://github.com/sandialabs/firewheel_repo_dns/blob/2acb4db042f219141b6a5947258124fff670214e/src/firewheel_repo_dns/populate_zones/plugin.py#L57) (almost certainly due to suggestions I made). 

This adds the `get` method to the `Vertex` object to provide that functionality. 