### PR TITLE
ci: Add new CI actions to autotag PRs and update release notes and changelog entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "deps:"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,141 @@
+# This release drafter follows the conventions
+# from https://keepachangelog.com
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: 🚀 Features
+    labels:
+      - feature
+      - enhancement
+  - title: 🐛 Bug Fixes
+    labels:
+      - fix
+      - bug
+  - title: ⚠️ Changes
+    labels:
+      - changed
+      - chore
+      - style
+      - refactor
+      - test
+      - perf
+      - chore
+  - title: ⚙️  Build/CI
+    labels:
+      - ci
+      - build
+  - title: ⛔️ Deprecated
+    labels:
+      - deprecated
+  - title: 🗑 Removed
+    labels:
+      - removed
+  - title: 🔐 Security
+    labels:
+      - security
+  - title: 📄 Documentation
+    labels:
+      - docs
+      - documentation
+  - title: 🧩 Dependency Updates
+    labels:
+      - deps
+      - dependencies
+    collapse-after: 5
+
+change-template: '- $TITLE @$AUTHOR ([#$NUMBER](https://github.com/sdelliot/testoss/pull/$NUMBER))'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+  patch:
+    labels:
+      - patch
+  default: patch
+  
+exclude-labels:
+  - skip-changelog
+
+autolabeler:
+  - label: 'feature'
+    branch:
+      - /(feature|feat)[-\/].+/
+    title:
+      - /(feature|feat)[:].+/
+  - label: 'fix'
+    branch:
+      - /(fix|bug|bugfix)[-/].+/
+    title:
+      - /(fix|bug|bugfix)[:].+/
+  - label: 'documentation'
+    branch:
+      - /(documentation|doc|docs)[-/].+/
+    title:
+      - /(documentation|doc|docs)[:].+/  
+    files:
+      - '*.rst'
+  - label: 'style'
+    branch:
+      - /(style)[-/].+/
+    title:
+      - /(style)[:].+/  
+  - label: 'refactor'
+    branch:
+      - /(refactor)[-/].+/
+    title:
+      - /(refactor)[:].+/  
+  - label: 'ci'
+    branch:
+      - /(ci)[-/].+/
+    title:
+      - /(ci)[:].+/  
+  - label: 'chore'
+    branch:
+      - /(chore)[-/].+/
+    title:
+      - /(chore)[:].+/
+  - label: 'refactor'
+    branch:
+      - /(refactor)[-/].+/
+    title:
+      - /(refactor)[:].+/
+  - label: 'perf'
+    branch:
+      - /(perf|performance)[-/].+/
+    title:
+      - /(perf|performance)[:].+/
+  - label: 'test'
+    branch:
+      - /(test|testing|tests)[-/].+/
+    title:
+      - /(test|testing|tests)[:].+/
+  - label: 'build'
+    branch:
+      - /(build)[-/].+/
+    title:
+      - /(build)[:].+/
+  - label: 'revert'
+    branch:
+      - /(revert)[-/].+/
+    title:
+      - /(revert)[:].+/
+  - label: 'dependencies'
+    branch:
+      - /(dependencies|deps)[-/].+/
+    title:
+      - /(dependencies|deps)[:].+/
+  - label: 'security'
+    branch:
+      - /(sec|security)[-/].+/
+    title:
+      - /(sec|security)[:].+/

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -49,7 +49,7 @@ categories:
       - dependencies
     collapse-after: 5
 
-change-template: '- $TITLE @$AUTHOR ([#$NUMBER](https://github.com/sdelliot/testoss/pull/$NUMBER))'
+change-template: '- $TITLE @$AUTHOR ([#$NUMBER](https://github.com/sandialabs/firewheel/pull/$NUMBER))'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:

--- a/.github/workflows/pr-title-checker.yaml
+++ b/.github/workflows/pr-title-checker.yaml
@@ -1,0 +1,60 @@
+name: "Lint Pull Request Title"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # We modified this initial list: https://github.com/commitizen/conventional-commit-types
+          # - feat: A new feature
+          # - fix/bug: A bug fix
+          # - docs/doc/documentation: Documentation only changes
+          # - style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+          # - refactor: A code change that neither fixes a bug nor adds a feature
+          # - perf: A code change that improves performance
+          # - test/tests/testing: Adding missing tests or correcting existing tests
+          # - build: Changes that affect the build system or external dependencies (example scopes: minimega, discovery)
+          # - ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+          # - chore: Other changes that don't modify src or test files
+          # - revert: Reverts a previous commit
+          # - deps/dependencies: Changes that updates dependencies
+          # - sec/security: Changes that impact security of the system
+          # - deprecate: Changes that deprecate some feature
+          types: |
+            feat
+            fix
+            bug
+            docs
+            doc
+            documentation
+            style
+            refactor
+            perf
+            test
+            tests
+            testing
+            build
+            ci
+            chore
+            revert
+            deps
+            dependencies  
+            sec
+            security
+          # Configure that a scope is not needed.
+          requireScope: false

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - main
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, edited, synchronize]
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
 
 permissions:
   contents: read

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,50 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    outputs:
+      latest_version: ${{ steps.draft_release.outputs.tag_name }}
+      release_notes: ${{ steps.draft_release.outputs.body }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Draft Release Notes
+        id: draft_release
+        uses: release-drafter/release-drafter@v6
+        with:
+          publish: ${{ steps.check-version.outputs.tag != '' }}
+          tag: ${{ steps.check-version.outputs.tag }}
+          disable-autolabeler: false
+          commitish: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  pr-checker:
+    name: Ensure Proper Pull Request Labels
+    if: ${{ always() }}
+    needs: update_release_draft
+    permissions:
+      pull-requests: read
+      checks: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: danielchabr/pr-labels-checker@v3.1
+        with:
+          hasSome: feature,fix,style,changed,refactor,perf,test,build,ci,chore,revert,deprecated,removed,security,documentation,dependencies
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -1,0 +1,33 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.tag_name }}
+          release-notes: ${{ github.event.release.body }}
+          compare-url-target-revision: ${{ github.event.release.target_commitish }}
+          parse-github-usernames: true
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: ${{ github.event.release.target_commitish }}
+          commit_message: 'docs(changelog): update changelog for version ${{ inputs.latest_version }}'
+          file_pattern: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased](https://github.com/sandialabs/firewheel/compare/v2.7.0...main)
 
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
-## [2.7.0] - 2024-11-15
+## [2.7.0](https://github.com/sandialabs/firewheel/releases/tag/v2.7.0) - 2024-11-15
 This is the initial Open Source release of FIREWHEEL!

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,7 +15,7 @@ Here is how you can get started:
 #. **Fork** FIREWHEEL to create your own copy of the project.
 
 #. **Create a branch** for the feature you want to work on.
-   Since the branch name will appear in the merge message, please use a sensible name such as 'fix-for-issue-123'.
+   Please use a sensible name such as 'fix-for-issue-123' or 'feat-my-new-feature'.
    Commit as you progress (``git add`` and ``git commit``).
    Use descriptive commit messages.
    Review the `Deprecation policy`_ to identify potential impact to users.
@@ -33,12 +33,28 @@ Here is how you can get started:
    To ensure you have a properly-configured development environment for running the tests, see `Build environment setup`_.
    If possible/necessary, new unit and/or functional tests should be added to ensure that the feature/bug is fully fixed.
 
-#. **Submit** your contribution as a new Pull Request to the master branch.
+#. **Submit** your contribution as a new Pull Request to the main branch.
+   We are following `Conventional Commits <https://www.conventionalcommits.org>`_ for pull request titles (e.g., ``feat: My new feature``.
+   The available types include:
+      - ``feat``: A new feature
+      - ``fix`` or ``bug``: A bug fix
+      - ``docs`` or ``doc`` or ``documentation``: Documentation only changes
+      - ``style``: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
+      - ``refactor``: A code change that neither fixes a bug nor adds a feature
+      - ``perf``: A code change that improves performance
+      - ``test`` or ``tests`` or ``testing``: Adding missing tests or correcting existing tests
+      - ``build``: Changes that affect the build system or external dependencies (example scopes: minimega, discovery)
+      - ``ci``: Changes to our CI configuration files and scripts (example scopes: GitLab, GitHub,)
+      - ``chore``: Other changes that don't modify src or test files
+      - ``revert``: Reverts a previous commit
+      - ``deps`` or ``dependencies``: Changes that updates dependencies
+      - ``sec`` or ``security``: Changes that impact security of the system
+      - ``deprecate``: Changes that deprecate some feature
    Please include an appropriate summary of the work and reference any issues which will be resolved.
    For example, if the PR will address bug, also add "Fixes #123" where 123 is the issue number.
-   If your code is not ready to merge, but you want to get feedback, please consider using ``WIP: <PR Title>`` as the title of your pull request.
+   If your code is not ready to merge, but you want to get feedback, please consider marking it as a draft.
    That way we will all know that it's not yet ready to merge and that you may be interested in more fundamental comments about design.
-   When you think the pull request is ready to merge, change the title (using the *Edit* button) to remove the ``WIP:``.
+   When you think the pull request is ready to merge, remove the draft marking.
 
 #. **Wait for review**.
    When a pull request is made, at least one reviewer (the other developers and interested community members) will assess the code and write inline and/or general comments on your Pull Request (PR) to help you improve its implementation, documentation, and style.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,20 +36,22 @@ Here is how you can get started:
 #. **Submit** your contribution as a new Pull Request to the main branch.
    We are following `Conventional Commits <https://www.conventionalcommits.org>`_ for pull request titles (e.g., ``feat: My new feature``.
    The available types include:
-      - ``feat``: A new feature
-      - ``fix`` or ``bug``: A bug fix
-      - ``docs`` or ``doc`` or ``documentation``: Documentation only changes
-      - ``style``: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
-      - ``refactor``: A code change that neither fixes a bug nor adds a feature
-      - ``perf``: A code change that improves performance
-      - ``test`` or ``tests`` or ``testing``: Adding missing tests or correcting existing tests
-      - ``build``: Changes that affect the build system or external dependencies (example scopes: minimega, discovery)
-      - ``ci``: Changes to our CI configuration files and scripts (example scopes: GitLab, GitHub,)
-      - ``chore``: Other changes that don't modify src or test files
-      - ``revert``: Reverts a previous commit
-      - ``deps`` or ``dependencies``: Changes that updates dependencies
-      - ``sec`` or ``security``: Changes that impact security of the system
-      - ``deprecate``: Changes that deprecate some feature
+
+   - ``feat``: A new feature
+   - ``fix`` or ``bug``: A bug fix
+   - ``docs`` or ``doc`` or ``documentation``: Documentation only changes
+   - ``style``: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
+   - ``refactor``: A code change that neither fixes a bug nor adds a feature
+   - ``perf``: A code change that improves performance
+   - ``test`` or ``tests`` or ``testing``: Adding missing tests or correcting existing tests
+   - ``build``: Changes that affect the build system or external dependencies (example scopes: minimega, discovery)
+   - ``ci``: Changes to our CI configuration files and scripts (example scopes: GitLab, GitHub,)
+   - ``chore``: Other changes that don't modify src or test files
+   - ``revert``: Reverts a previous commit
+   - ``deps`` or ``dependencies``: Changes that updates dependencies
+   - ``sec`` or ``security``: Changes that impact security of the system
+   - ``deprecate``: Changes that deprecate some feature
+   
    Please include an appropriate summary of the work and reference any issues which will be resolved.
    For example, if the PR will address bug, also add "Fixes #123" where 123 is the issue number.
    If your code is not ready to merge, but you want to get feedback, please consider marking it as a draft.


### PR DESCRIPTION
This PR is an effort to improve the OSS development process for FIREWHEEL. In it, we add the following GitHub actions:

-  [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) - Validate that PR titles have the general style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). We have also extended the default list to add a few new commit "types".
- [release-drafter/release-drafter](https://github.com/release-drafter/release-drafter) - Drafts the next release notes as pull requests are merged into main. 
   - This action also includes an "autolabeler" which checks the branch name and PR title to automatically add a label to the request.
- [danielchabr/pr-labels-checker](https://github.com/danielchabr/pr-labels-checker) - Github Action to check if a PR has at least one of the expected labels
- [stefanzweifel/changelog-updater-action](https://github.com/stefanzweifel/changelog-updater-action) - A GitHub Action to automatically update a "Keep a Changelog" CHANGELOG with the latest release notes.

These four actions work together to ensure that each PR will be accurately labeled and that, when merged, will ensure that the release notes are correctly updated. Finally, when we issue a release, the changelog will also be updated. This has been tested in a separate repository and seems to work as expected.

Note that this PR will fail the CI pipeline as the release-drafter configuration is not in our default branch yet.