### PR TITLE
ci: Enhance CI reusability

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Prepare to use tox-based environments
-      uses: ./.github/actions/prepare-tox
+      uses: sandialabs/firewheel/.github/actions/prepare-tox
     - name: Build Documentation
       run: |
         tox -e dependencies,docs

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Prepare to use tox-based environments
-      uses: ./.github/actions/prepare-tox
+      uses: sandialabs/firewheel/.github/actions/prepare-tox
     - name: Lint code
       run: |
         tox -e lint

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,11 +38,11 @@ jobs:
                                 openvswitch-switch qemu-kvm qemu-utils dnsmasq \
                                 ntfs-3g iproute2 libpcap-dev
     - name: Prepare minimega
-      uses: ./.github/actions/prepare-minimega
+      uses: sandialabs/firewheel/.github/actions/prepare-minimega
     - name: Prepare discovery
-      uses: ./.github/actions/prepare-discovery
+      uses: sandialabs/firewheel/.github/actions/prepare-discovery
     - name: Prepare FIREWHEEL
-      uses: ./.github/actions/prepare-firewheel
+      uses: sandialabs/firewheel/.github/actions/prepare-firewheel
     - name: Run unit tests
       run: |
         firewheel test unit -m 'not long and not mcs' \

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,7 +45,7 @@ Here is how you can get started:
    - ``perf``: A code change that improves performance
    - ``test`` or ``tests`` or ``testing``: Adding missing tests or correcting existing tests
    - ``build``: Changes that affect the build system or external dependencies (example scopes: minimega, discovery)
-   - ``ci``: Changes to our CI configuration files and scripts (example scopes: GitLab, GitHub,)
+   - ``ci``: Changes to our CI configuration files and scripts (example scopes: GitLab, GitHub)
    - ``chore``: Other changes that don't modify src or test files
    - ``revert``: Reverts a previous commit
    - ``deps`` or ``dependencies``: Changes that updates dependencies


### PR DESCRIPTION
CI pipelines for model component repos currently cannot access the composite actions that are called in the reusable workflows for this repo. It seems that this is because [GitHub actions defined in a called repo](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#overview) (e.g., `sandialabs/firewheel`) are executed as if they were defined in the caller repo (e.g., the MC repo).

An example of this failing behavior can be [found in the recent CI pipeline](https://github.com/sandialabs/firewheel_repo_dns/actions/runs/13420030343/job/37490153500#step:4:1) for the `firewheel_repo_dns` repo. That repo cannot find `.github/actions/prepare-tox` because it's looking for it in the `sandialabs/firewheel_repo_dns` repository rather than `sandialabs/firewheel` where it actually lives.

I was hoping there might be a way to tell the caller repo to look for things in the called repo, but the closest related info I've found so far is [an issue suggesting this might not be possible](https://github.com/orgs/community/discussions/66094). There are many suggestions there, including those for choosing specific branches, but I think that it probably just makes the most sense for us to use the full path to the action (e.g., `sandialabs/firewheel/.github/actions/prepare-tox`) in our workflows until we need a more sophisticated system.

I quote the link to that issue here as a place to go looking if we eventually need a more complete strategy, such as a new repo only containing actions and similar to the CodeQL Action repo that is linked there. 