### PR TITLE
ci: Updating CI to use specific tagged versions of github actions and minimizing/enforcing permissions for all actions.

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,6 +11,9 @@ on:
   # Allow reuse across the FIREWHEEL ecosystem
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
 

--- a/.github/workflows/pr-title-checker.yaml
+++ b/.github/workflows/pr-title-checker.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Validate Pull Request Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@40166f0
+      - uses: amannn/action-semantic-pull-request@40166f00814508ec3201fc8595b393d451c8cd80
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-title-checker.yaml
+++ b/.github/workflows/pr-title-checker.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Validate Pull Request Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@40166f0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,16 +4,14 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   update_release_draft:
@@ -25,12 +23,9 @@ jobs:
       latest_version: ${{ steps.draft_release.outputs.tag_name }}
       release_notes: ${{ steps.draft_release.outputs.body }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Draft Release Notes
         id: draft_release
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@b1476f6
         with:
           publish: ${{ steps.check-version.outputs.tag != '' }}
           tag: ${{ steps.check-version.outputs.tag }}
@@ -47,7 +42,7 @@ jobs:
       checks: write
     runs-on: ubuntu-latest
     steps:
-      - uses: danielchabr/pr-labels-checker@v3.1
+      - uses: danielchabr/pr-labels-checker@7145ecb
         with:
           hasSome: feature,fix,style,changed,refactor,perf,test,build,ci,chore,revert,deprecated,removed,security,documentation,dependencies
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Draft Release Notes
         id: draft_release
-        uses: release-drafter/release-drafter@b1476f6
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5
         with:
           publish: ${{ steps.check-version.outputs.tag != '' }}
           tag: ${{ steps.check-version.outputs.tag }}
@@ -42,7 +42,7 @@ jobs:
       checks: write
     runs-on: ubuntu-latest
     steps:
-      - uses: danielchabr/pr-labels-checker@7145ecb
+      - uses: danielchabr/pr-labels-checker@7145ecb81a69104f99767cb133bf856e749f7e73
         with:
           hasSome: feature,fix,style,changed,refactor,perf,test,build,ci,chore,revert,deprecated,removed,security,documentation,dependencies
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   LOG_DIR: /var/log/firewheel
   MINIMEGA_CONFIG: /etc/minimega/minimega.conf

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.event.release.target_commitish }}
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@b3a7ae7
+        uses: stefanzweifel/changelog-updater-action@b3a7ae7d4afc1d6982949a79bcd939fbcb245871
         with:
           latest-version: ${{ github.event.release.tag_name }}
           release-notes: ${{ github.event.release.body }}
@@ -26,7 +26,7 @@ jobs:
           parse-github-usernames: true
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@c86fa26
+        uses: stefanzweifel/git-auto-commit-action@c86fa26bedab90b9a250e22f66759c0c50699f15
         with:
           branch: ${{ github.event.release.target_commitish }}
           commit_message: 'docs(changelog): update changelog for version ${{ inputs.latest_version }}'

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.event.release.target_commitish }}
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@b3a7ae7
         with:
           latest-version: ${{ github.event.release.tag_name }}
           release-notes: ${{ github.event.release.body }}
@@ -26,7 +26,7 @@ jobs:
           parse-github-usernames: true
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@c86fa26
         with:
           branch: ${{ github.event.release.target_commitish }}
           commit_message: 'docs(changelog): update changelog for version ${{ inputs.latest_version }}'


### PR DESCRIPTION
This set of changes should enable a more secure CI pipeline (e.g., avoiding supply chain attacks) while still maintaining the current functionality. I suspect that the pipeline will still fail prior to merge due to some of the restrictions. Any issues after that can be addressed quickly.