### PR TITLE
fix: Correct behavior of the SSH Manager for quoted strings

### DIFF
--- a/src/firewheel/cli/ssh_manager.py
+++ b/src/firewheel/cli/ssh_manager.py
@@ -446,7 +446,7 @@ class SSHManager(_SSHProtocolManager):
         """
         args, optlist = super(SSHManager, cls).parse_cli_input(argv)
         # All but the first positional argument are elements of the command
-        destination, command = args[0], " ".join(args[1:])
+        destination, command = args[0], shlex.join(args[1:])
         return [destination, command], optlist
 
 
@@ -641,7 +641,7 @@ class ParallelSSHManager(_SSHProtocolManager):
         """
         args, optlist = super(ParallelSSHManager, cls).parse_cli_input(argv)
         # All but the first positional argument are elements of the command
-        destination, command = args[0], " ".join(args[1:])
+        destination, command = args[0], shlex.join(args[1:])
         return [destination, command], optlist
 
 
@@ -751,7 +751,7 @@ class SCPManager(_SSHProtocolManager):
             str: The complete SSH instruction.
         """
         instruction_options = self._prepare_options(options)
-        return f"scp {instruction_options} {' '.join(sources)} {target}"
+        return f"scp {instruction_options} {shlex.join(sources)} {target}"
 
     @classmethod
     def parse_cli_input(cls, argv):

--- a/src/firewheel/tests/unit/cli/test_ssh_manager.py
+++ b/src/firewheel/tests/unit/cli/test_ssh_manager.py
@@ -89,8 +89,16 @@ class TestSSHManager(_TestSSHProtocolManager):
             capture_output=False,
         )
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "ls -la",
+            "grep 'test string' file.txt",
+            "'grep \"test string\" file.txt'",
+        ]
+    )
     @patch("subprocess.run")
-    def test_call_ssh_with_command(self, mock_subprocess, ssh):
+    def test_call_ssh_with_command(self, mock_subprocess, command, ssh):
         # Mock a successful SSH call
         mock_subprocess.return_value.returncode = 0
 


### PR DESCRIPTION
@gregjacobus was running into an issue where the SSH manager would fail to execute a `grep` command when it was passed via the command line. It appears that the issue stemmed from a failure to use `shlex` when recombining arguments parsed from the command line.

This updates the SSH manager to ensure that `shlex` is used for all parsing and recombining operations when manipulating arguments passed to as commands to the SSH/SCP commands. 

The PR also adds a few extra test cases to have better coverage of quoted commands.