### PR TITLE
ci: fixing an issue where checking for labels fails

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,11 @@
 name: Publish FIREWHEEL Docker Image
-on: [push]
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+
 jobs:
   push-to-ghcr:
     name: Push Docker image to GitHub Packages

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,8 @@ on:
       - opened
       - reopened
       - synchronize
+      - labeled
+      - unlabeled
 
 permissions:
   contents: read
@@ -42,7 +44,7 @@ jobs:
       checks: write
     runs-on: ubuntu-latest
     steps:
-      - uses: danielchabr/pr-labels-checker@7145ecb81a69104f99767cb133bf856e749f7e73
+      - uses: docker://agilepathway/pull-request-label-checker:sha-c3d16ad
         with:
-          hasSome: feature,fix,style,changed,refactor,perf,test,build,ci,chore,revert,deprecated,removed,security,documentation,dependencies
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          any_of: feature,fix,style,changed,refactor,perf,test,build,ci,chore,revert,deprecated,removed,security,documentation,dependencies
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In addition to fixing the CI pipeline for label checking, this PR and stops building docker containers for all branches and only does so for pushes to main or a new release.