### PR TITLE
ci: Run PR label check only in pull request contexts

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   update_release_draft:
+    name: Update the release notes
     permissions:
       contents: write
       pull-requests: write
@@ -37,7 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   pr-checker:
     name: Ensure Proper Pull Request Labels
-    if: ${{ always() }}
+    if: github.event_name == 'pull_request_target'
     needs: update_release_draft
     permissions:
       pull-requests: read


### PR DESCRIPTION
This is intended to only run the PR label checker for events occuring in a pull request context (cases where the `event_name` is `pull_request_target` and not pushes).