### PR TITLE
ci: Fix pydocstyle version to prevent linting errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ basepython = python3
 skip_install = true
 deps =
     flake8~=7.0.0
-    pydoclint[flake8]
+    pydoclint[flake8]==0.6.2
 commands =
     flake8 {toxinidir}/src/firewheel/ {posargs}
 


### PR DESCRIPTION
This PR fixes the pipeline, currently broken after an update to pydocstyle. We did not previously pin a pydocstyle version in [`tox.ini`](https://github.com/sandialabs/firewheel/blob/986cb66cbfcd2d6adadbb1fa19b9eced838462aa/tox.ini#L38).

A new command line option ([`--ignore-private-args`](https://jsh9.github.io/pydoclint/config_options.html#14---ignore-private-args-shortform--ipa-default-false)) was [added in pydocstyle 0.6.3](https://github.com/jsh9/pydoclint/blob/main/CHANGELOG.md#063---2025-03-30). The default value of that argument—which I believe we should be defaulting to—is `False` (e.g., _do not_ ignore private arguments); however, it seems like even though we are specifying private arguments in our docstrings, the check is still failing.

This PR does not solve the problem or advocate any solution, it simply pins the previous behavior to fix the pipeline while we determine the best course of action.

Closes #103. 