### PR TITLE
fix: Ensure that repository access is resilient against namespace packages

### DIFF
--- a/src/firewheel/control/repository_db.py
+++ b/src/firewheel/control/repository_db.py
@@ -68,7 +68,12 @@ class RepositoryDb:
 
         # Add all model components that have been added via entry points
         for entry in entry_points(group="firewheel.mc_repo"):
-            entries.append({"path": entry.load()[0]})
+            # Typically `entry` is a `__path__` attribute of a module; this attribute
+            # is defined as a sequence of strings enumerating the locations where the
+            # package's submodules will be found
+            # https://docs.python.org/3/reference/import.html#path-attributes-on-modules
+            for path in entry.load():
+                entries.append({"path": path})
 
         return iter(entries)
 


### PR DESCRIPTION
We install MCs by registering the MC repo's `__path__` attribute as an entry point. That `__path__` attribute [is a sequence](https://docs.python.org/3/reference/import.html#path-attributes-on-modules), and FIREWHEEL currently grabs the first item in that sequence to be the repository path.

However, it appears that when an MC package repo does not have a top-level `__init__.py` (e.g., [`firewheel_repo_dns`](https://github.com/sandialabs/firewheel_repo_dns/tree/main/src/firewheel_repo_dns)) and it is installed in editable mode, that package is treated as a [namespace package](https://docs.python.org/3/reference/import.html#namespace-packages). In this case, the path that we would like to register via the entry point is not necessarily the first item in the sequence (it looks like the first entry is the empty placeholder directory in the `site-packages` location, and the second entry is / may be the path to the actual modules). 

I've put a bit of thought into how to resolve this problem, and my thinking is that there might not be a downside to including every item in the `__path__` sequence. For one thing, this way we don't have to make any assumptions about where in our sequence the path we really want will be. It could be first, second, last, wherever. Path elements of `__path__` that do not have MC modules are ignored as repositories by the `mc list` helper. And, in the case that someone actually does make an MC repo a _real_ namespace package (e.g., a package where the components are not actually in the same repo, I think), we will still include all of the elements.

An alternative is that we just include an `__init__.py` at the top-level all of our MC package repos, but the missing one in `firewheel_repo_dns` suggests that this might be a route that persistently gives rise to tricky bugs if that empty, often-not-required, seemingly useless file is missing. We'd need to make sure that gets documented really well.