### PR TITLE
feat: Support for using Ansible playbooks for installing model components

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@
 .install_firewheel_docker: &install_firewheel_docker
   - python -m pip install $PIP_ARGS -U build setuptools pip
   - python -m build
-  - python -m pip install -e .[dev]
+  - python -m pip install -e .[dev,mcs]
 
 .install_firewheel: &install_firewheel
   - sudo killall minimega  # Make sure minimega is not running

--- a/install.sh
+++ b/install.sh
@@ -104,25 +104,6 @@ function install_firewheel_generic() {
 
 }
 
-#######################################
-# Installing the FIREWHEEL package with standard dependencies.
-# Arguments:
-#     None
-# Globals:
-#     FIREWHEEL_ROOT
-#     PIP_ARGS
-#     PYTHON_BIN
-#######################################
-function install_firewheel() {
-    pushd "${FIREWHEEL_ROOT_DIR}"
-    ${PYTHON_BIN} -m pip install ${PIP_ARGS} firewheel[mcs]
-    if [ ! $? -eq 0 ];
-    then
-        install_firewheel_generic
-        ${PYTHON_BIN} -m pip install ${PIP_ARGS} --prefer-binary ./dist/firewheel-2.6.0.tar.gz
-    fi
-    popd
-}
 
 #######################################
 # Installing the FIREWHEEL package with development dependencies.
@@ -252,8 +233,8 @@ function main() {
         echo "${fw_str} Installing FIREWHEEL in development mode."
         install_firewheel_development
     else
-        echo "${fw_str} Installing FIREWHEEL without development dependencies."
-        install_firewheel
+        echo "${fw_str} Installing FIREWHEEL with standard (non-development) dependencies."
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} firewheel[mcs]
     fi
     echo "${fw_str} Setting configuration options."
     init_firewheel $static

--- a/install.sh
+++ b/install.sh
@@ -229,7 +229,7 @@ function install_firewheel_generic() {
 #######################################
 function install_firewheel() {
     pushd "${FIREWHEEL_ROOT_DIR}"
-    ${PYTHON_BIN} -m pip install ${PIP_ARGS} firewheel
+    ${PYTHON_BIN} -m pip install ${PIP_ARGS} firewheel[mcs]
     if [ ! $? -eq 0 ];
     then
         install_firewheel_generic
@@ -248,22 +248,12 @@ function install_firewheel() {
 #     PYTHON_BIN
 #######################################
 function install_firewheel_development() {
-    pushd "${FIREWHEEL_ROOT_DIR}"
-    install_firewheel_generic
-
-    # Install the development version.
-    if [[ $1 -eq 1 ]]; then
-    then
-        # In this case, we do not use the "dev" optional dependencies as
-        # the user is using the source code version of these model components, rather
-        # than the Python package installed repositories.
-        ${PYTHON_BIN} -m pip install ${PIP_ARGS} pre-commit tox
-        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e .[format,docs]
-
-    else
-        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e .[dev]
-    fi
-    popd
+    # Install the development version of FIREWHEEL
+    ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${FIREWHEEL_ROOT_DIR}/[dev]
+    # Essential MCs (base, linux, vyos, etc.) were cloned; install them in development mode too
+    ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_base
+    ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_linux
+    ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_vyos
 }
 
 #######################################
@@ -384,7 +374,7 @@ function main() {
     fi
     if [[ $dev -eq 1 ]]; then
         echo "${fw_str} Installing FIREWHEEL in development mode."
-        install_firewheel_development $clone
+        install_firewheel_development
     else
         echo "${fw_str} Installing FIREWHEEL without development dependencies."
         install_firewheel

--- a/install.sh
+++ b/install.sh
@@ -91,12 +91,13 @@ function check_deps() {
 #     PYTHON_BIN
 #######################################
 function install_firewheel_development() {
+    local mc_dir="${MC_DIR}_packages"
     # Install the development version of FIREWHEEL
     ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${FIREWHEEL_ROOT_DIR}/[dev]
     # Essential MCs (base, linux, vyos, etc.) were cloned; install them in development mode too
-    ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_base
-    ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_linux
-    ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_vyos
+    ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${mc_dir}/firewheel_repo_base
+    ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${mc_dir}/firewheel_repo_linux
+    ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${mc_dir}/firewheel_repo_vyos
 }
 
 #######################################

--- a/install.sh
+++ b/install.sh
@@ -217,13 +217,11 @@ function post_install() {
 #######################################
 function usage() {
     echo -e "Useful script to install FIREWHEEL and ensure proper system configuration.\n"
-    echo "usage: install.sh [-h | --help] [-d | --development] [-nc | --no-clone] [-s | --static]"
+    echo "usage: install.sh [-h | --help] [-d | --development] [-s | --static]"
     echo -e "\n\nOptional Arguments:"
     echo "  -h, --help           Show this help message and exit"
     echo "  -d, --development    Install FIREWHEEL in development mode, an 'editable' installation"
     echo "                       including all development dependencies."
-    echo "  -nc, --no-clone      Prevents the install script from cloning/installing any model component"
-    echo "                       repositories."
     echo "  -s, --static         Does not check if necessary system services are running (e.g., minimega)."
 }
 
@@ -232,14 +230,11 @@ function usage() {
 #######################################
 function main() {
     local dev=0
-    local clone=1
     local static=0
     while [[ "$1" != "" ]]; do
         case $1 in
             -d | --development )    shift
                 dev=1 ;;
-            -nc | --no-clone )       shift
-                clone=0 ;;
             -s | --static )    shift
                 static=1 ;;
             -h | --help )           usage

--- a/install.sh
+++ b/install.sh
@@ -80,30 +80,6 @@ function check_deps() {
     fi
 }
 
-#######################################
-# Basic setup for upgrading the virtual envionment tools and
-# building the FIREWHEEL whl file.
-# Arguments:
-#     None
-# Globals:
-#     PIP_ARGS
-#     PYTHON_BIN
-#######################################
-function install_firewheel_generic() {
-    if ! ${PYTHON_BIN} -m pip install ${PIP_ARGS} build; then
-        err "FIREWHEEL setup failed to pip install 'build'."
-        err "Consult the pip error logs, and verify network connectivity. Aborting."
-        exit 1
-    fi
-
-    if ! ${PYTHON_BIN} -m build; then
-        err "FIREWHEEL setup failed to build the source distribution and wheel."
-        err "Consult the error logs, and verify network connectivity. Aborting."
-        exit 1
-    fi
-
-}
-
 
 #######################################
 # Installing the FIREWHEEL package with development dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ classifiers = [
     "Topic :: System :: Operating System",
 ]
 dependencies = [
+    "ansible-runner>=2.0.0,<=2.4.1",
     "minimega==2.9",
     "ClusterShell<=1.9.3",
     "colorama<=0.4.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ docs = [
     "sphinx-design",
 ]
 dev = [
-    "firewheel[mcs,format,docs]",
+    "firewheel[format,docs]",
     "pre-commit",
     "tox~=4.0",
 ]

--- a/src/firewheel/config/config-template.yaml
+++ b/src/firewheel/config/config-template.yaml
@@ -1,3 +1,4 @@
+ansible: {}
 attribute_defaults: {}
 cli:
     cache_dir: fw_cli

--- a/src/firewheel/config/config-template.yaml
+++ b/src/firewheel/config/config-template.yaml
@@ -1,4 +1,5 @@
-ansible: {}
+ansible:
+    cache_type: online
 attribute_defaults: {}
 cli:
     cache_dir: fw_cli

--- a/src/firewheel/control/ansible_playbooks/git.yml
+++ b/src/firewheel/control/ansible_playbooks/git.yml
@@ -30,8 +30,9 @@
 
     - name: Move cached files to the desired location
       ansible.builtin.copy:
-        src: /tmp/fwcache/{{ item.source }}
-        dest: {{ item.destination }}
+        src: "/tmp/fwcache/{{ item.source }}"
+        dest: "{{ item.destination }}"
+        mode: 0666
       loop: "{{ cached_files }}"
 
     - name: Remove the Git repository

--- a/src/firewheel/control/ansible_playbooks/git.yml
+++ b/src/firewheel/control/ansible_playbooks/git.yml
@@ -1,38 +1,40 @@
 ---
 # This playbook will clone a Git repository and move specified cached files
-# The user will be prompted for all relevant Git information including:
-# - The repository URL
-# - The branch name (optional)
-# - The access token (if required for authentication)
+# If you are using an access token, you can specify it in the `git_server` URL
+# For example: https://<token>@github.com/user/repo.git
+# The user will need to provide all relevant information including:
+# - ``git_server`` - The URL of the git server
+# - ``git_repo_path`` - The path to the repo from the server
+# - ``git_branch`` - The branch name (optional); default: main
 
 - name: Clone Git repository and move files
   hosts: localhost
   vars_prompt:
     - name: git_server
       prompt: "Please enter the Git server URL or set `ansible.git_server` in the FIREWHEEL configuration."
-      private: no
-    
+      private: false
+
     - name: git_repo_path
       prompt: "Please enter the path to the git repository or set `ansible.git_repo_path` in the FIREWHEEL configuration."
-      private: no
+      private: false
 
   tasks:
     - name: Clone the Git repository
-      git:
+      ansible.builtin.git:
         repo: "{{ git_server }}/{{ git_repo_path }}"
         dest: "/tmp/fwcache"
         version: "{{ git_branch | default('main') }}"
-        clone: yes
-        update: yes
-        # If using an access token, you can specify it in the URL
-        # For example: https://<token>@github.com/user/repo.git
+        clone: true
+        update: true
       register: git_clone_result
 
     - name: Move cached files to the desired location
-      command: mv /tmp/fwcache/{{ item.source }} ./{{ item.destination }}
+      ansible.builtin.copy:
+        src: /tmp/fwcache/{{ item.source }}
+        dest: {{ item.destination }}
       loop: "{{ cached_files }}"
 
     - name: Remove the Git repository
-      file:
+      ansible.builtin.file:
         path: "/tmp/fwcache"
         state: absent

--- a/src/firewheel/control/ansible_playbooks/git.yml
+++ b/src/firewheel/control/ansible_playbooks/git.yml
@@ -9,11 +9,11 @@
   hosts: localhost
   vars_prompt:
     - name: git_server
-      prompt: "Please enter the Git server URL"
+      prompt: "Please enter the Git server URL or set `ansible.git_server` in the FIREWHEEL configuration."
       private: no
     
     - name: git_repo_path
-      prompt: "Please enter the path to the git repository"
+      prompt: "Please enter the path to the git repository or set `ansible.git_repo_path` in the FIREWHEEL configuration."
       private: no
 
   tasks:
@@ -31,7 +31,6 @@
     - name: Move cached files to the desired location
       command: mv /tmp/fwcache/{{ item.source }} ./{{ item.destination }}
       loop: "{{ cached_files }}"
-      when: git_clone_result.changed
 
     - name: Remove the Git repository
       file:

--- a/src/firewheel/control/ansible_playbooks/git.yml
+++ b/src/firewheel/control/ansible_playbooks/git.yml
@@ -1,0 +1,39 @@
+---
+# This playbook will clone a Git repository and move specified cached files
+# The user will be prompted for all relevant Git information including:
+# - The repository URL
+# - The branch name (optional)
+# - The access token (if required for authentication)
+
+- name: Clone Git repository and move files
+  hosts: localhost
+  vars_prompt:
+    - name: git_server
+      prompt: "Please enter the Git server URL"
+      private: no
+    
+    - name: git_repo_path
+      prompt: "Please enter the path to the git repository"
+      private: no
+
+  tasks:
+    - name: Clone the Git repository
+      git:
+        repo: "{{ git_server }}/{{ git_repo_path }}"
+        dest: "/tmp/fwcache"
+        version: "{{ git_branch | default('main') }}"
+        clone: yes
+        update: yes
+        # If using an access token, you can specify it in the URL
+        # For example: https://<token>@github.com/user/repo.git
+      register: git_clone_result
+
+    - name: Move cached files to the desired location
+      command: mv /tmp/fwcache/{{ item.source }} ./{{ item.destination }}
+      loop: "{{ cached_files }}"
+      when: git_clone_result.changed
+
+    - name: Remove the Git repository
+      file:
+        path: "/tmp/fwcache"
+        state: absent

--- a/src/firewheel/control/ansible_playbooks/s3.yml
+++ b/src/firewheel/control/ansible_playbooks/s3.yml
@@ -12,23 +12,23 @@
   vars_prompt:
     - name: s3_endpoint
       prompt: "Please enter the S3 instance endpoint URL"
-      private: no
+      private: false
 
     - name: s3_bucket
       prompt: "Please enter the S3 bucket name"
-      private: no
+      private: false
 
     - name: aws_access_key_id
       prompt: "Please enter the S3 access key"
-      private: yes
+      private: true
 
     - name: aws_secret_access_key
       prompt: "Please enter the S3 secret key"
-      private: yes
+      private: true
 
   tasks:
     - name: Download cached files from custom S3
-      aws_s3:
+      amazon.aws.s3_object:
         bucket: "{{ s3_bucket }}"
         object: "{{ item.source }}"
         dest: "{{ item.destination }}"

--- a/src/firewheel/control/ansible_playbooks/s3.yml
+++ b/src/firewheel/control/ansible_playbooks/s3.yml
@@ -1,0 +1,39 @@
+---
+# This playbook will loop through all values in the `cached_files` variable
+# and collected those cached files from an S3 instance.
+# The user will be prompted for all relevant S3 information including:
+# - The instance URL
+# - The bucket name
+# - The access key
+# - The secret key
+
+- name: Download files from an S3 instance
+  hosts: localhost
+  vars_prompt:
+    - name: s3_endpoint
+      prompt: "Please enter the S3 instance endpoint URL"
+      private: no
+
+    - name: s3_bucket
+      prompt: "Please enter the S3 bucket name"
+      private: no
+
+    - name: aws_access_key_id
+      prompt: "Please enter the S3 access key"
+      private: yes
+
+    - name: aws_secret_access_key
+      prompt: "Please enter the S3 secret key"
+      private: yes
+
+  tasks:
+    - name: Download cached files from custom S3
+      aws_s3:
+        bucket: "{{ s3_bucket }}"
+        object: "{{ item.source }}"
+        dest: "./{{ item.destination }}"
+        mode: get
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        endpoint_url: "{{ s3_endpoint }}"
+      loop: "{{ cached_files }}"

--- a/src/firewheel/control/ansible_playbooks/s3.yml
+++ b/src/firewheel/control/ansible_playbooks/s3.yml
@@ -2,10 +2,10 @@
 # This playbook will loop through all values in the `cached_files` variable
 # and collected those cached files from an S3 instance.
 # The user will be prompted for all relevant S3 information including:
-# - The instance URL
-# - The bucket name
-# - The access key
-# - The secret key
+# - ``s3_endpoint`` - The instance URL
+# - ``s3_bucket`` - The bucket name
+# - ``aws_access_key_id`` - The access key
+# - ``aws_secret_access_key`` - The secret key
 
 - name: Download files from an S3 instance
   hosts: localhost
@@ -31,7 +31,7 @@
       aws_s3:
         bucket: "{{ s3_bucket }}"
         object: "{{ item.source }}"
-        dest: "./{{ item.destination }}"
+        dest: "{{ item.destination }}"
         mode: get
         aws_access_key: "{{ aws_access_key_id }}"
         aws_secret_key: "{{ aws_secret_access_key }}"

--- a/src/firewheel/control/model_component_install.py
+++ b/src/firewheel/control/model_component_install.py
@@ -149,11 +149,14 @@ class ModelComponentInstall:
 
         Returns:
             bool: :py:data:`True` if the playbook executed successfully, :py:data:`False` otherwise.
+
+        Raises:
+            ValueError: If an invalid ansible.cash_type is provided in the FIREWHEEL config.
         """
         console = Console()
 
         ansible_config = {
-            "ansible_remote_tmp" : config["system"]["default_output_dir"],
+            "ansible_remote_tmp": config["system"]["default_output_dir"],
         }
 
         # Add any remaining configuration options provided in the FIREWHEEL
@@ -170,28 +173,36 @@ class ModelComponentInstall:
             cached_files = []
 
             # Read the playbook file to get the cached_files variables
-            with open(install_path, 'r') as file:
+            with open(install_path, "r") as file:
                 playbook = yaml.safe_load(file)
 
             # Extract variables from the playbook
             variables = {}
             for play in playbook:
-                if 'vars' in play:
-                    variables.update(play['vars'])
+                if "vars" in play:
+                    variables.update(play["vars"])
 
             cached_files = variables.get("cached_files", [])
 
             # Now we need to update the destination path for all the cached files
             # we can prepend the directory of the original install file.
             for file in cached_files:
-                file["destination"] = str(install_path.parent / Path(file["destination"]))
+                file["destination"] = str(
+                    install_path.parent / Path(file["destination"])
+                )
 
             # Call the cache playbook from the ansible_playbooks directory
-            cache_playbook_path = Path(__file__).resolve().parent / Path(f"ansible_playbooks/{cache_type}.yml")
+            cache_playbook_path = Path(__file__).resolve().parent / Path(
+                f"ansible_playbooks/{cache_type}.yml"
+            )
 
             if not cache_playbook_path.exists():
                 # Get a list of all cache types
-                available_types = [file.stem for file in cache_playbook_path.parent.iterdir() if file.is_file()]
+                available_types = [
+                    file.stem
+                    for file in cache_playbook_path.parent.iterdir()
+                    if file.is_file()
+                ]
                 console.print(
                     f"[b red]Failed to find cache_type=[cyan]{cache_type}[/cyan]."
                     f"Available types are: [magenta]{available_types}[/magenta]"
@@ -211,9 +222,9 @@ class ModelComponentInstall:
 
             # Now we need to ensure the config has these properties
             # so that it will properly take in values passed.
-            rc.input_fd=sys.stdin
-            rc.output_fd=sys.stdout
-            rc.error_fd=sys.stderr
+            rc.input_fd = sys.stdin
+            rc.output_fd = sys.stdout
+            rc.error_fd = sys.stderr
             cache_runner = ansible_runner.Runner(config=rc)
 
             # Ensure we are using subprocess mode

--- a/src/firewheel/control/model_component_install.py
+++ b/src/firewheel/control/model_component_install.py
@@ -189,6 +189,15 @@ class ModelComponentInstall:
             # Call the cache playbook from the ansible_playbooks directory
             cache_playbook_path = Path(__file__).resolve().parent / Path(f"ansible_playbooks/{cache_type}.yml")
 
+            if not cache_playbook_path.exists():
+                # Get a list of all cache types
+                available_types = [file.stem for file in cache_playbook_path.parent.iterdir() if file.is_file()]
+                console.print(
+                    f"[b red]Failed to find cache_type=[cyan]{cache_type}[/cyan]."
+                    f"Available types are: [magenta]{available_types}[/magenta]"
+                )
+                raise ValueError("Available `cache_type` are: {available_types}")
+
             # By defining everything here, we can enable prompt's as we will no longer
             # use pexpect by default, but rather use subprocess, enabling stdin
             # See: https://github.com/ansible/ansible-runner/issues/1399

--- a/src/firewheel/control/model_component_install.py
+++ b/src/firewheel/control/model_component_install.py
@@ -102,6 +102,10 @@ class ModelComponentInstall:
         if self.is_ansible_playbook(install_path):
             return self.run_ansible_playbook(install_path)
 
+        console.print(
+            "[b yellow]Warning: Use of non-ansible-based INSTALL scripts is deprecated. "
+            "Please contact the model component developer to transition this file."
+        )
         try:
             # We have already checked with the user to ensure that they want to run
             # this script.

--- a/src/firewheel/control/model_component_install.py
+++ b/src/firewheel/control/model_component_install.py
@@ -9,8 +9,8 @@ from rich.prompt import PromptBase
 from rich.syntax import Syntax
 from rich.console import Console
 
-from firewheel.lib.log import Log
 from firewheel.config import config
+from firewheel.lib.log import Log
 
 
 class InstallPrompt(PromptBase[str]):
@@ -173,7 +173,7 @@ class ModelComponentInstall:
             cached_files = []
 
             # Read the playbook file to get the cached_files variables
-            with open(install_path, "r") as file:
+            with open(install_path, "r", encoding="utf-8") as file:
                 playbook = yaml.safe_load(file)
 
             # Extract variables from the playbook
@@ -207,7 +207,7 @@ class ModelComponentInstall:
                     f"[b red]Failed to find cache_type=[cyan]{cache_type}[/cyan]."
                     f"Available types are: [magenta]{available_types}[/magenta]"
                 )
-                raise ValueError("Available `cache_type` are: {available_types}")
+                raise ValueError(f"Available `cache_type` are: {available_types}")
 
             # By defining everything here, we can enable prompt's as we will no longer
             # use pexpect by default, but rather use subprocess, enabling stdin
@@ -241,7 +241,8 @@ class ModelComponentInstall:
                 return True
             else:
                 console.print(
-                    f"[b red]Failed to collect cached files via: [cyan]{cache_type}[/cyan]; Failed with return code {ret.rc}."
+                    f"[b red]Failed to collect cached files via: [cyan]{cache_type}[/cyan]; "
+                    f"Failed with return code {ret.rc}."
                 )
                 return False
 


### PR DESCRIPTION
## Current State
Currently, some Model Components may require additional data to be downloaded (e.g., VM resources, etc.) that cannot or should not be stored within the MC repo package. In this case, the Model Components can have an `INSTALL` file, which can be any executable script (as denoted by a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line). See: [Model Component INSTALL file](https://sandialabs.github.io/firewheel/model_component/mc_install.html#mc-install).

This PR enables using [Ansible](https://ansible.readthedocs.io/) playbooks in lieu of using a bash-based script.

## Primary Benefits
There are several primary motivators for this change:
1. [**Idempotence**](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_intro.html#id6) - By design, it is significantly easier to design Ansible playbooks that can be run multiple times without changing the final state. Specifically, this is necessary when installation fails and needs to be re-run. While other scripts can have this property, Ansible makes it significantly easier to do so.
2. **Readability** - `INSTALL` files that are written with Shell scripts are significantly harder to read/understand than Ansible-based YAML. This not only impacts maintainability, but also the security as reviewing shell code for issues is more difficult. 
3. **Pulling Cached Files** - Downloading files and creating VM Resources or images each time FIREWHEEL is installed is time consuming and, in the case of offline installations, impractical. The common solution for this is to perform this action once and cache the resulting files. By using Ansible, FIREWHEEL can provide a few common ways to retrieve these cached files. When combined with the Idempotence of Ansible scripts, this will further reduce installation errors and speed new installs.

## Key Changes
1. A new top-level FIREWHEEL config option called `ansible` where there is a subkey `cache_type="online"`. That is, by default assume that the system is online and will not pull from any kind of cached system. This top-level option will enable users to add other values (URLs, API Keys, etc.) for getting the various cached files.
2. New Ansible playbooks that support caching from Amazon S3 buckets and from Git repositories.
3. Modifications to the `model_component_install.py` to check and see if the `INSTALL` script is a valid Ansible playbook. If it is, then we will use [ansible-runner](https://pypi.org/project/ansible-runner/) to execute the script. Otherwise, the existing behavior is maintained.

## Pending Tasks

- [ ] The relevant documentation needs to be updated to describe these options.
- [ ] Test cases for the new install code would be valuable, though it may be difficult to construct.
- [ ] Additional cache options should be supported. Options include: JFrog Artifactory, a standard [get_url](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html), MS Onedrive,  etc. These can also be added in future PRs as need arises.