### PR TITLE
fix: Clearly delineate between editable/non-editable MC installs

### DIFF
--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -192,7 +192,7 @@ Once the configuration options have been set, run ``install.sh``:
     chmod +x install.sh
     ./install.sh
 
-This script will create necessary directories, installs and configures FIREWHEEL, and clone our default model component repositories.
+This script will create necessary directories, install and configure FIREWHEEL, and install our default model component repositories.
 The script will optionally install additional FIREWHEEL development dependencies by using either the ``-d`` or ``--development`` flag::
 
     ./install.sh -d
@@ -207,10 +207,23 @@ Once the entire cluster has been provisioned, we recommend running the :ref:`com
 
 Installing Model Component Repositories
 ---------------------------------------
-Before running any experiments, you will likely need to clone several Model Component repositories and install them.
-For example, you will likely want to install our ``base`` and ``linux`` repository.
-We recommend putting all Model Component repositories in ``/opt/firewheel/model_components``.
-Then you can *install* this location so that FIREWHEEL can leverage those model components::
+Before running any experiments, you will likely need to install several Model Component repositories.
+Model Component repositories provide extra features and customizations that give FIREWHEEL experiments their flexibility and modularity.
+
+There are two ways to install Model Components.
+The first and easiest way is to use a premade Model Component repository which has been converted into a (pip-installable) Python package.
+Several of the most commonly used FIREWHEEL Model Components exist in this format, for example the ``base`` and ``linux`` Model Components.
+
+.. code-block:: bash
+
+   pip install firewheel_repo_base
+
+A selection of these MCs are installed by the ``install.sh`` script.
+
+The second way to install a Model Component is using FIREWHEEL's helpers.
+This is a good solution for Model Component repositories that are either built or cloned to a local directory.
+We recommend putting all these Model Component repositories in ``/opt/firewheel/model_components``.
+Then you can use the *install* helper to add this location as a known FIREWHEEL Model Component repository::
 
     firewheel repository install /opt/firewheel/model_components
 

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -223,7 +223,8 @@ A selection of these MCs are installed by the ``install.sh`` script.
 The second way to install a Model Component is using FIREWHEEL's helpers.
 This is a good solution for Model Component repositories that are either built or cloned to a local directory.
 We recommend putting all these Model Component repositories in ``/opt/firewheel/model_components``.
-Then you can use the *install* helper to add this location as a known FIREWHEEL Model Component repository::
+Then you can use the :ref:`helper_repository_install` to add this location as a known FIREWHEEL Model Component repository::
+
 
     firewheel repository install /opt/firewheel/model_components
 

--- a/install.sh
+++ b/install.sh
@@ -230,11 +230,6 @@ function install_firewheel_generic() {
 function install_firewheel() {
     pushd "${FIREWHEEL_ROOT_DIR}"
     ${PYTHON_BIN} -m pip install ${PIP_ARGS} firewheel
-    if [ ! $? -eq 0 ];
-    then
-        install_firewheel_generic
-        ${PYTHON_BIN} -m pip install ${PIP_ARGS} --prefer-binary ./dist/firewheel-2.6.0.tar.gz
-    fi
     popd
 }
 

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 # head node. Then your FIREWHEEL cluster will be ready to use!
 #
 # Requirements:
-# * Python >=3.7, with the path to its executable specified by PYTHON_BIN
+# * Python >=3.8, with the path to its executable specified by PYTHON_BIN
 #   (we recommend using virtual environments).
 # * minimega and discovery installed and configured.
 

--- a/install.sh
+++ b/install.sh
@@ -223,14 +223,21 @@ function install_firewheel_generic() {
 # Arguments:
 #     None
 # Globals:
-#     FIREWHEEL_ROOT
+#     FIREWHEEL_ROOT_DIR
 #     PIP_ARGS
 #     PYTHON_BIN
 #######################################
 function install_firewheel() {
-    pushd "${FIREWHEEL_ROOT_DIR}"
-    ${PYTHON_BIN} -m pip install ${PIP_ARGS} firewheel
-    popd
+    local clone="$1"
+
+    if [[ $clone -eq 0 ]]; then
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} ${FIREWHEEL_ROOT_DIR}/[mcs]
+    else
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} ${FIREWHEEL_ROOT_DIR}/
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} ${MC_DIR}/firewheel_repo_base
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} ${MC_DIR}/firewheel_repo_linux
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} ${MC_DIR}/firewheel_repo_vyos
+    fi
 }
 
 #######################################
@@ -238,29 +245,27 @@ function install_firewheel() {
 # Arguments:
 #     None
 # Globals:
-#     FIREWHEEL_ROOT
+#     FIREWHEEL_ROOT_DIR
 #     PIP_ARGS
 #     PYTHON_BIN
 #######################################
 function install_firewheel_development() {
     local clone="$1"
-    pushd "${FIREWHEEL_ROOT_DIR}"
     install_firewheel_generic
 
     # Install the development version.
     if [[ $clone -eq 0 ]]; then
-        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e .[dev]
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${FIREWHEEL_ROOT_DIR}/[dev]
     else
         # In this case, we do not use the "dev" optional dependencies as
         # the user is using the source code version of these model components, rather
         # than the Python package installed repositories.
         ${PYTHON_BIN} -m pip install ${PIP_ARGS} pre-commit tox
-        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e .[format,docs]
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${FIREWHEEL_ROOT_DIR}/[format,docs]
         ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_base
         ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_linux
         ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_vyos
     fi
-    popd
 }
 
 #######################################
@@ -383,8 +388,8 @@ function main() {
         echo "${fw_str} Installing FIREWHEEL in development mode."
         install_firewheel_development $clone
     else
-        echo "${fw_str} Installing FIREWHEEL without development dependencies."
-        install_firewheel
+        echo "${fw_str} Installing FIREWHEEL with standard (non-development) dependencies."
+        install_firewheel $clone
     fi
     echo "${fw_str} Setting configuration options."
     init_firewheel $static

--- a/install.sh
+++ b/install.sh
@@ -253,7 +253,6 @@ function install_firewheel_development() {
 
     # Install the development version.
     if [[ $1 -eq 1 ]]; then
-    then
         # In this case, we do not use the "dev" optional dependencies as
         # the user is using the source code version of these model components, rather
         # than the Python package installed repositories.

--- a/install.sh
+++ b/install.sh
@@ -243,19 +243,22 @@ function install_firewheel() {
 #     PYTHON_BIN
 #######################################
 function install_firewheel_development() {
+    local clone="$1"
     pushd "${FIREWHEEL_ROOT_DIR}"
     install_firewheel_generic
 
     # Install the development version.
-    if [[ $1 -eq 1 ]]; then
+    if [[ $clone -eq 0 ]]; then
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e .[dev]
+    else
         # In this case, we do not use the "dev" optional dependencies as
         # the user is using the source code version of these model components, rather
         # than the Python package installed repositories.
         ${PYTHON_BIN} -m pip install ${PIP_ARGS} pre-commit tox
         ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e .[format,docs]
-
-    else
-        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e .[dev]
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_base
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_linux
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_vyos
     fi
     popd
 }


### PR DESCRIPTION
This captures a handful of the higher priority elements introduced by #91, while focusing on backwards compatibility. 

The primary modification here is to make more clear the distinction between cloned/uncloned editable/non-editable installs and have the docs adequately reflect the actions in the `install.sh` script. Previously, the documentation stated that the installer would clone our default model components, which was true before we transitioned to the package model. As we've made that transition, some of the implied functionality has been lost—right now, running the install script with no arguments will clone MCs but not install them... so still technically accurate, but somewhat misleading because we do not mention that any further actions to be taken. In a similar way, calling the script with `--no-clone` will also not clone MCs, but will also not install them even though one could argue that a familiar user (e.g., me) might expect `--no-clone` to not _clone_ the MC repos, but still install them using pip. There are a few other similar logic cases, but I won't discuss them at length. Instead, I'll summarize the behavior of the script as would be defined by this MR:

|  CLI Option          | (clone)  | `--no-clone` |
|------------------|---------|---------------|
| (production)         | pip install model components from cloned versions | pip install model components from PyPI  |
| `--development` | pip install model components from cloned versions in editable mode | pip install model components from PyPI (same as above) |

In all cases, when using this script, FIREWHEEL will be installed from this local version not PyPI. I don't think that's actually the case right now (looking at the line in the `install_firewheel` function), but this seems like it would be the expected behavior of running this script. Presumably, whoever's running the install script in the repo is doing it because they want to install that version of FIREWHEEL, not just have it turn around and download whatever the latest version is on PyPI.