### PR TITLE
fix: Fixing namespaces

### DIFF
--- a/src/firewheel/cli/helpers/start
+++ b/src/firewheel/cli/helpers/start
@@ -73,7 +73,11 @@ MM_BASE_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.base_dir)"
 MINIMEGA_BIN="$MM_INSTALL_DIR/bin/minimega -base=$MM_BASE_DIR"
 
 # Ensure the specified namespace is created and that localhost is added
-$MINIMEGA_BIN -e namespace "$(firewheel config get minimega.namespace)"
+namespace="$(firewheel config get minimega.namespace)"
+if [ $($MINIMEGA_BIN -e .filter namespace="$namespace" .filter active=true .headers false namespace | wc -l) -eq 0 ]; then
+    # We were not in the specified namespace yet
+    $MINIMEGA_BIN -e namespace "$namespace"
+fi
 $MINIMEGA_BIN -e ns add-hosts localhost
 DONE
 

--- a/src/firewheel/cli/helpers/start
+++ b/src/firewheel/cli/helpers/start
@@ -39,7 +39,7 @@ MM_INSTALL_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.install_d
 MM_BASE_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.base_dir)"
 MINIMEGA_BIN="$MM_INSTALL_DIR/bin/minimega -base=$MM_BASE_DIR"
 $MINIMEGA_BIN -e clear all
-$MINIMEGA_BIN -e namespace "$(firewheel config get minimega.namespace)"
+$MINIMEGA_BIN -e namespace "$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.namespace)"
 $MINIMEGA_BIN -e ns add-hosts localhost
 $MINIMEGA_BIN -e ns queueing true
 
@@ -73,7 +73,7 @@ MM_BASE_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.base_dir)"
 MINIMEGA_BIN="$MM_INSTALL_DIR/bin/minimega -base=$MM_BASE_DIR"
 
 # Ensure the specified namespace is created and that localhost is added
-namespace="$(firewheel config get minimega.namespace)"
+namespace="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.namespace)"
 if [ $($MINIMEGA_BIN -e .filter namespace="$namespace" .filter active=true .headers false namespace | wc -l) -eq 0 ]; then
     # We were not in the specified namespace yet
     $MINIMEGA_BIN -e namespace "$namespace"

--- a/src/firewheel/cli/helpers/start
+++ b/src/firewheel/cli/helpers/start
@@ -66,6 +66,18 @@ fi
 
 DONE
 
+
+RUN Shell ON compute
+MM_INSTALL_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.install_dir)"
+MM_BASE_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.base_dir)"
+MINIMEGA_BIN="$MM_INSTALL_DIR/bin/minimega -base=$MM_BASE_DIR"
+
+# Ensure the specified namespace is created and that localhost is added
+$MINIMEGA_BIN -e namespace "$(firewheel config get minimega.namespace)"
+$MINIMEGA_BIN -e ns add-hosts localhost
+DONE
+
+
 RUN Python ON control
 #!/usr/bin/env python
 import sys

--- a/src/firewheel/cli/helpers/start
+++ b/src/firewheel/cli/helpers/start
@@ -39,7 +39,7 @@ MM_INSTALL_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.install_d
 MM_BASE_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.base_dir)"
 MINIMEGA_BIN="$MM_INSTALL_DIR/bin/minimega -base=$MM_BASE_DIR"
 $MINIMEGA_BIN -e clear all
-$MINIMEGA_BIN -e namespace firewheel
+$MINIMEGA_BIN -e namespace "$(firewheel config get minimega.namespace)"
 $MINIMEGA_BIN -e ns add-hosts localhost
 $MINIMEGA_BIN -e ns queueing true
 

--- a/src/firewheel/cli/helpers/stop/hard
+++ b/src/firewheel/cli/helpers/stop/hard
@@ -161,7 +161,7 @@ sudo systemctl restart minimega
 MM_INSTALL_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.install_dir)"
 MM_BASE_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.base_dir)"
 MINIMEGA_BIN="$MM_INSTALL_DIR/bin/minimega -base=$MM_BASE_DIR"
-$MINIMEGA_BIN -e clear namespace firewheel
+$MINIMEGA_BIN -e clear namespace "$(firewheel config get minimega.namespace)"
 DONE
 
 RUN Helpers ON control

--- a/src/firewheel/cli/helpers/stop/hard
+++ b/src/firewheel/cli/helpers/stop/hard
@@ -161,7 +161,7 @@ sudo systemctl restart minimega
 MM_INSTALL_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.install_dir)"
 MM_BASE_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.base_dir)"
 MINIMEGA_BIN="$MM_INSTALL_DIR/bin/minimega -base=$MM_BASE_DIR"
-$MINIMEGA_BIN -e clear namespace "$(firewheel config get minimega.namespace)"
+$MINIMEGA_BIN -e clear namespace "$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.namespace)"
 DONE
 
 RUN Helpers ON control

--- a/src/firewheel/cli/helpers/stop/index
+++ b/src/firewheel/cli/helpers/stop/index
@@ -33,7 +33,7 @@ RUN Shell ON control
 MM_INSTALL_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.install_dir)"
 MM_BASE_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.base_dir)"
 MINIMEGA_BIN="$MM_INSTALL_DIR/bin/minimega -base=$MM_BASE_DIR"
-$MINIMEGA_BIN -e clear namespace "$(firewheel config get minimega.namespace)"
+$MINIMEGA_BIN -e clear namespace "$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.namespace)"
 DONE
 
 RUN Helpers ON compute

--- a/src/firewheel/cli/helpers/stop/index
+++ b/src/firewheel/cli/helpers/stop/index
@@ -33,7 +33,7 @@ RUN Shell ON control
 MM_INSTALL_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.install_dir)"
 MM_BASE_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.base_dir)"
 MINIMEGA_BIN="$MM_INSTALL_DIR/bin/minimega -base=$MM_BASE_DIR"
-$MINIMEGA_BIN -e clear namespace firewheel
+$MINIMEGA_BIN -e clear namespace "$(firewheel config get minimega.namespace)"
 DONE
 
 RUN Helpers ON compute

--- a/src/firewheel/lib/minimega/api.py
+++ b/src/firewheel/lib/minimega/api.py
@@ -49,11 +49,17 @@ class minimegaAPI:  # noqa: N801
         self.mm_base = mm_base
         self.mm_socket = os.path.join(self.mm_base, "minimega")
 
+        try:
+            namespace = config["minimega"]["namespace"]
+        except KeyError as exp:
+            self.log.warn("minimega namespace not set, using default")
+            namespace = None
+
         if not os.path.exists(self.mm_socket):
             self.log.error("minimega socket does not exist at: %s", self.mm_socket)
             raise RuntimeError(f"minimega socket does not exist at: {self.mm_socket}")
         try:
-            self.mm = minimega.minimega(self.mm_socket, True, False, None)
+            self.mm = minimega.minimega(self.mm_socket, True, False, namespace)
         except Exception as exp:
             self.log.error("minimega connection failed.")
             self.log.exception(exp)

--- a/src/firewheel/lib/minimega/api.py
+++ b/src/firewheel/lib/minimega/api.py
@@ -51,8 +51,8 @@ class minimegaAPI:  # noqa: N801
 
         try:
             namespace = config["minimega"]["namespace"]
-        except KeyError as exp:
-            self.log.warn("minimega namespace not set, using default")
+        except KeyError:
+            self.log.warning("minimega namespace not set, using default")
             namespace = None
 
         if not os.path.exists(self.mm_socket):

--- a/src/firewheel/lib/minimega/api.py
+++ b/src/firewheel/lib/minimega/api.py
@@ -49,12 +49,8 @@ class minimegaAPI:  # noqa: N801
         self.mm_base = mm_base
         self.mm_socket = os.path.join(self.mm_base, "minimega")
 
-        try:
-            namespace = config["minimega"]["namespace"]
-        except KeyError:
+        if (namespace := config["minimega"].get("namespace")) is None:
             self.log.warning("minimega namespace not set, using default")
-            namespace = None
-
         if not os.path.exists(self.mm_socket):
             self.log.error("minimega socket does not exist at: %s", self.mm_socket)
             raise RuntimeError(f"minimega socket does not exist at: {self.mm_socket}")


### PR DESCRIPTION
This fixes FIREWHEEL working in a cluster. There are a few places where the minimega namespace was hard-coded.

I cannot figure out why this change is necessary now, but everything seemed to work in the past. Doesn't seem like the minimega API changed at all. Not sure it's necessarily important, but would love to know if anybody has comments.

TODO: 

- [x] Check if minimega API version matters and fix dependency accordingly