### PR TITLE
chore: Tightening dependencies to address python 3.8 support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -255,13 +255,13 @@ function install_firewheel_development() {
 
     # Install the development version.
     if [[ $clone -eq 0 ]]; then
-        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${FIREWHEEL_ROOT_DIR}/[dev]
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${FIREWHEEL_ROOT_DIR}/[dev,mcs]
     else
-        # In this case, we do not use the "dev" optional dependencies as
+        # In this case, we do not use the "mcs" optional dependencies as
         # the user is using the source code version of these model components, rather
         # than the Python package installed repositories.
         ${PYTHON_BIN} -m pip install ${PIP_ARGS} pre-commit tox
-        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${FIREWHEEL_ROOT_DIR}/[format,docs]
+        ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${FIREWHEEL_ROOT_DIR}/[dev]
         ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_base
         ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_linux
         ${PYTHON_BIN} -m pip install ${PIP_ARGS} -e ${MC_DIR}/firewheel_repo_vyos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,21 +76,21 @@ dependencies = [
 
 [project.optional-dependencies]
 mcs = [
-    "firewheel-repo-base",
-    "firewheel-repo-linux",
-    "firewheel-repo-vyos",
+    # "firewheel-repo-base",
+    # "firewheel-repo-linux",
+    # "firewheel-repo-vyos",
 ]
 format = [
     "ruff==0.11.2",
 ]
 docs = [
     "Sphinx>=7.0.0,<=8.2.3",
-    "myst-nb==1.2.0",
+    "myst-nb<=1.2.0",
     "sphinx-rtd-theme==3.0.2",
     "sphinxcontrib-spelling==8.0.1",
     "sphinx-copybutton==0.5.2",
     "pyenchant==3.2.2",
-    # "doc8==1.1.2",
+    "doc8==1.1.2",
     "pip-licenses==5.0.0",
     "sphinx-design==0.6.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ keywords = [
     "experimentation",
     "minimega",
 ]
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 license-files = ["LICENSE", "DISCLAIMER.md", "COPYRIGHT.md", "NOTICE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -76,9 +76,9 @@ dependencies = [
 
 [project.optional-dependencies]
 mcs = [
-    # "firewheel-repo-base",
-    # "firewheel-repo-linux",
-    # "firewheel-repo-vyos",
+    "firewheel-repo-base",
+    "firewheel-repo-linux",
+    "firewheel-repo-vyos",
 ]
 format = [
     "ruff==0.11.2",
@@ -87,7 +87,7 @@ docs = [
     "Sphinx>=7.0.0,<=8.2.3",
     "myst-nb<=1.2.0",
     "sphinx-rtd-theme==3.0.2",
-    "sphinxcontrib-spelling==8.0.1",
+    "sphinxcontrib-spelling>=7.0.0,<=8.0.1",
     "sphinx-copybutton==0.5.2",
     "pyenchant==3.2.2",
     "doc8==1.1.2",
@@ -95,7 +95,7 @@ docs = [
     "sphinx-design==0.6.1",
 ]
 dev = [
-    "firewheel[mcs,format,docs]",
+    "firewheel[format,docs]",
     "pre-commit",
     "tox~=4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -22,7 +22,8 @@ keywords = [
     "experimentation",
     "minimega",
 ]
-license = {text = "Apache License (2.0)"}
+license = "Apache-2.0"
+license-files = ["LICENSE", "DISCLAIMER.md", "COPYRIGHT.md", "NOTICE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -30,7 +31,6 @@ classifiers = [
     "Intended Audience :: Information Technology",
     "Intended Audience :: Telecommunications Industry",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
@@ -54,13 +54,15 @@ classifiers = [
     "Topic :: System :: Operating System",
 ]
 dependencies = [
+    "ansible>=6.0.0,<=12.0.0",
+    "ansible-runner>=2.0.0,<=2.4.1",
     "minimega==2.9",
     "ClusterShell<=1.9.3",
     "colorama<=0.4.6",
     "coverage<=7.7.1",
     "grpcio>=1.63.0,<=1.68.1",
     "grpcio-tools>=1.63.0,<=1.68.1",
-    "importlib_metadata>=3.6,<=8.6.1",
+    "importlib_metadata>=7.0.0,<=8.6.1",
     "Jinja2>=3.1.2,<=3.1.6",
     "netaddr<=1.3.0,>=0.7.0",
     "networkx>=2.3,<=3.4.2",
@@ -70,7 +72,7 @@ dependencies = [
     "python-dotenv<=1.0.1",
     "PyYAML<=6.0.2",
     "qemu.qmp==0.0.3",
-    "requests>=2.22.0,<=2.32.3",
+    "requests>=2.31.0,<=2.32.3",
     "rich>=13.6.0,<13.10",
 ]
 
@@ -81,20 +83,18 @@ mcs = [
     "firewheel-repo-vyos",
 ]
 format = [
-    "ruff==0.11.2",      # Linting/formatting
-    "beautysh~=6.2.1",  # Format/lint shell scripts
+    "ruff==0.11.2",
 ]
 docs = [
-    "Sphinx",
-    "myst-nb",
-    "sphinx-rtd-theme>=1.2.0",
-    "sphinxcontrib-spelling",
-    "sphinx-copybutton",
-    "pyenchant",
-    "minimega",
-    "doc8",
-    "pip-licenses",
-    "sphinx-design",
+    "Sphinx>=7.0.0,<=8.2.3",
+    "myst-nb>=1.0.0,<=1.2.0",
+    "sphinx-rtd-theme>=3.0.0",
+    "sphinxcontrib-spelling>=7.0.0,<=8.0.1",
+    "sphinx-copybutton==0.5.2",
+    "pyenchant==3.2.2",
+    "doc8==1.1.2",
+    "pip-licenses==5.0.0",
+    "sphinx-design==0.6.1",
 ]
 dev = [
     "firewheel[mcs,format,docs]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77.0", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=75.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -54,8 +54,6 @@ classifiers = [
     "Topic :: System :: Operating System",
 ]
 dependencies = [
-    "ansible>=6.0.0,<=12.0.0",
-    "ansible-runner>=2.0.0,<=2.4.1",
     "minimega==2.9",
     "ClusterShell<=1.9.3",
     "colorama<=0.4.6",
@@ -86,10 +84,10 @@ format = [
     "ruff==0.11.2",
 ]
 docs = [
-    "Sphinx>=7.0.0,<=8.2.3",
-    "myst-nb>=1.0.0,<=1.2.0",
-    "sphinx-rtd-theme>=3.0.0",
-    "sphinxcontrib-spelling>=7.0.0,<=8.0.1",
+    "Sphinx>=8.0.0,<=8.2.3",
+    "myst-nb==1.2.0",
+    "sphinx-rtd-theme==3.0.2",
+    "sphinxcontrib-spelling==8.0.1",
     "sphinx-copybutton==0.5.2",
     "pyenchant==3.2.2",
     "doc8==1.1.2",
@@ -132,7 +130,6 @@ disallow_any_unimported = true
 show_traceback = true
 pretty = true
 python_version = "3.8"
-new_type_inference = true
 enable_error_code = ["ignore-without-code", "redundant-expr"]
 show_error_code_links = true
 disallow_untyped_calls = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=75.0", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=75.0,<=77.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -22,8 +22,7 @@ keywords = [
     "experimentation",
     "minimega",
 ]
-license = "Apache-2.0"
-license-files = ["LICENSE", "DISCLAIMER.md", "COPYRIGHT.md", "NOTICE"]
+license = {text = "Apache-2.0"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -112,6 +111,9 @@ firewheel = "firewheel.cli.firewheel_cli:main"
 mcg = "firewheel.control.utils.new_model_component:main"
 prep_fw_tab_completion = "firewheel.cli.completion.prepare_completion_script:main"
 get_fw_tab_completion_script = "firewheel.cli.completion.prepare_completion_script:print_completion_script_path"
+
+[tools.setuptools]
+license-files = ["LICENSE", "DISCLAIMER.md", "COPYRIGHT.md", "NOTICE"]
 
 [tool.setuptools.package-data]
 # Required for tox documentation building

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "python-dotenv<=1.0.1",
     "PyYAML<=6.0.2",
     "qemu.qmp==0.0.3",
-    "requests>=2.31.0,<=2.32.3",
+    "requests==2.32.3",
     "rich>=13.6.0,<13.10",
 ]
 
@@ -84,13 +84,13 @@ format = [
     "ruff==0.11.2",
 ]
 docs = [
-    "Sphinx>=8.0.0,<=8.2.3",
+    "Sphinx>=7.0.0,<=8.2.3",
     "myst-nb==1.2.0",
     "sphinx-rtd-theme==3.0.2",
     "sphinxcontrib-spelling==8.0.1",
     "sphinx-copybutton==0.5.2",
     "pyenchant==3.2.2",
-    "doc8==1.1.2",
+    # "doc8==1.1.2",
     "pip-licenses==5.0.0",
     "sphinx-design==0.6.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ keywords = [
     "experimentation",
     "minimega",
 ]
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 license-files = ["LICENSE", "DISCLAIMER.md", "COPYRIGHT.md", "NOTICE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ deps =
     {[testenv:flake8]deps}
 commands =
     firewheel docs {toxinidir}/docs/source/cli
-    ; doc8 {toxinidir}/docs/source
+    doc8 {toxinidir}/docs/source
     {[testenv:flake8]commands}
     all: sphinx-build -E -W -b spelling {toxinidir}/docs/source/ {toxinidir}/docs/build/spelling
     all: sphinx-build -E -n -b linkcheck {toxinidir}/docs/source/ {toxinidir}/docs/build/linkcheck

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ deps =
     {[testenv:flake8]deps}
 commands =
     firewheel docs {toxinidir}/docs/source/cli
-    doc8 {toxinidir}/docs/source
+    ; doc8 {toxinidir}/docs/source
     {[testenv:flake8]commands}
     all: sphinx-build -E -W -b spelling {toxinidir}/docs/source/ {toxinidir}/docs/build/spelling
     all: sphinx-build -E -n -b linkcheck {toxinidir}/docs/source/ {toxinidir}/docs/build/linkcheck

--- a/tox.ini
+++ b/tox.ini
@@ -48,10 +48,12 @@ commands =
 [testenv:shell]
 # This is currently broken with Python 3.12
 # Until this is fixed, we will remove it from our
-# CI testing: `tox -e shell -- logs/fw_cli/*.sh logs/fw_cli/*/*.sh`
+# CI testing: `tox -e shell -- /scratch/firewheel/fw_cli/*.sh /scratch/firewheel/fw_cli/*/*.sh`
 # See: https://github.com/lovesegfault/beautysh/issues/248
 basepython = python3
 extras = format
+deps =
+    beautysh
 commands =
     beautysh --indent-size 4 --force-function-style fnpar --check {toxinidir}/install.sh {toxinidir}/src/firewheel/cli/completion/completion-template.sh {posargs}
 


### PR DESCRIPTION
[Setuptools 77 ](https://github.com/pypa/setuptools/blob/12ca0186ba7d9bf387d65400bb05205d0bcf9e56/NEWS.rst#v7700) added license expression ([PEP 639](https://peps.python.org/pep-0639/#add-license-expression-field)) support. However, this breaks the current method of how setuptools checks for the license (see https://github.com/pypa/setuptools/issues/4903). While upgrading is ideal, given our continued support for Python 3.8, we must instead lock in the version of setuptools. Additionally, this PR locks in several other packages to address similar deprecation and Python 3.8 issues. 

Lastly, this PR addresses some circular dependency challenges which occurred when installing firewheel[dev]. These changes should fix (and stablize) our CI pipeline as well.