### PR TITLE
feat(cli): Adding a new firewheel config edit command

### DIFF
--- a/docs/source/cli/commands.rst
+++ b/docs/source/cli/commands.rst
@@ -35,6 +35,22 @@ Users can interact with the :ref:`command_config` command (i.e. ``firewheel conf
 series of sub-commands which enable easily getting/setting various configuration options.
 
 
+.. _command_config_edit:
+
+config edit
+^^^^^^^^^^^
+
+usage: firewheel config edit [-e EDITOR]
+
+Edit the FIREWHEEL configuration with a text editor. The user must set either the VISUAL or EDITOR
+environment variable or use the provided flag to override these environment variables.
+
+options:
+  -e EDITOR, --editor EDITOR
+                        Use the specified text editor.
+
+
+
 .. _command_config_get:
 
 config get
@@ -339,3 +355,4 @@ Example:
 
         $ firewheel version
         2.6.0
+

--- a/docs/source/cli/helper_docs.rst
+++ b/docs/source/cli/helper_docs.rst
@@ -1508,3 +1508,4 @@ Example
 ``firewheel vm resume host.root.net bgp.root.net``
 
 ``firewheel vm resume --all``
+

--- a/src/firewheel/cli/configure_firewheel.py
+++ b/src/firewheel/cli/configure_firewheel.py
@@ -117,7 +117,7 @@ class ConfigureFirewheel(cmd.Cmd):
         # Attempt to open the file with the chosen editor
         try:
             subprocess.run([editor, Config(writable=True).config_path], check=True)
-        except subprocess.CalledProcessError:
+        except (FileNotFoundError, subprocess.CalledProcessError):
             console.print(
                 f"Error: Failed to open FIREWHEEL configuration with '{editor}'.\n",
                 style="bold red",

--- a/src/firewheel/cli/configure_firewheel.py
+++ b/src/firewheel/cli/configure_firewheel.py
@@ -1,11 +1,14 @@
+import os
 import cmd
 import pprint
 import argparse
 import operator
+import subprocess
 from inspect import cleandoc
 from pathlib import Path
 
 import yaml
+from rich.console import Console
 
 from firewheel.config import Config
 from firewheel.lib.log import Log
@@ -63,6 +66,64 @@ class ConfigureFirewheel(cmd.Cmd):
             help="Path of the configuration file to be reset.",
         )
         return parser
+
+    def define_edit_parser(self) -> argparse.ArgumentParser:
+        """Create an :py:class:`argparse.ArgumentParser` for :ref:`command_config_edit`.
+
+        Returns:
+            argparse.ArgumentParser: The parser needed for :ref:`command_config_edit`.
+        """
+        parser = argparse.ArgumentParser(
+            description=str(
+                "Edit the FIREWHEEL configuration with a text editor. "
+                "The user must set either the VISUAL or EDITOR environment variable "
+                "or use the provided flag to override these environment variables."
+            ),
+            prog="firewheel config edit",
+            add_help=False,
+        )
+        parser.add_argument(
+            "-e",
+            "--editor",
+            required=False,
+            default="",
+            help="Use the specified text editor.",
+        )
+        return parser
+
+    def do_edit(self, args: str = "") -> None:
+        """
+        Edit the FIREWHEEL config with the default text editor as determined by
+        the ``VISUAL`` or ``EDITOR`` environment variables.
+        If no editor is found an error message is output.
+
+        Args:
+            args (str): A string of arguments passed in by the user.
+        """
+        # Create a Console object for colored output
+        console = Console()
+
+        # Get the parser for the reset command
+        parser = self.define_edit_parser()
+        cmd_args = self._handle_parsing(parser, args)
+
+        # Check for VISUAL, then EDITOR
+        editor = cmd_args.editor or os.environ.get("VISUAL") or os.environ.get("EDITOR")
+
+        if not editor:
+            self.help_edit()
+            return
+
+        # Attempt to open the file with the chosen editor
+        try:
+            subprocess.run([editor, Config(writable=True).config_path], check=True)
+        except subprocess.CalledProcessError:
+            console.print(
+                f"Error: Failed to open FIREWHEEL configuration with '{editor}'.\n",
+                style="bold red",
+            )
+            self.help_edit()
+            return
 
     def do_reset(self, args: str = "") -> None:
         """
@@ -261,6 +322,18 @@ class ConfigureFirewheel(cmd.Cmd):
                 command_string += clean_text
                 command_string += "\n\n"
         return command_string
+
+    def _help_edit(self) -> str:
+        """Help message for the :py:meth:`do_edit` sub-command.
+
+        Returns:
+            str: The help message.
+        """
+        return self.define_edit_parser().format_help()
+
+    def help_edit(self) -> None:
+        """Print help for the :py:meth:`do_edit` sub-command."""
+        print(self._help_edit())
 
     def _help_reset(self) -> str:
         """Help message for the :py:meth:`do_reset` sub-command.

--- a/src/firewheel/tests/unit/cli/test_cli_configure.py
+++ b/src/firewheel/tests/unit/cli/test_cli_configure.py
@@ -128,6 +128,23 @@ class CliConfigureTestCase(unittest.TestCase):
         self.assertEqual(self.old_config, test_config)
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+    def test_do_edit_param_invalid(self, mock_stdout):
+        args = "-e asdf"
+        self.cli.do_edit(args)
+
+        msg = "Error: Failed to open FIREWHEEL configuration with"
+        self.assertIn(msg, mock_stdout.getvalue())
+
+    @unittest.mock.patch.dict(os.environ, {'EDITOR': '', 'VISUAL': ''})
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+    def test_do_edit_none(self, mock_stdout):
+        args = ""
+        self.cli.do_edit(args)
+
+        msg = "Edit the FIREWHEEL configuration"
+        self.assertIn(msg, mock_stdout.getvalue())
+
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def test_emptyline(self, mock_stdout):
         # Test the configuration from initialization
         cli = ConfigureFirewheel()
@@ -158,6 +175,13 @@ class CliConfigureTestCase(unittest.TestCase):
         self.cli.help_set()
 
         msg = "Set a FIREWHEEL configuration."
+        self.assertIn(msg, mock_stdout.getvalue())
+
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+    def test_help_edit(self, mock_stdout):
+        self.cli.help_edit()
+
+        msg = "Edit the FIREWHEEL configuration"
         self.assertIn(msg, mock_stdout.getvalue())
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)


### PR DESCRIPTION
This PR adds a new command which enables users to easily edit the FIREWHEEL configuration. The `firewheel config edit` command will automatically use the `VISUAL` or `EDITOR` environment variables. Alternatively, users can pass in their own editor of choice (or override the environment variables). This PR also updates the associated documentation.