### PR TITLE
feat: Adding new docker build paramameters

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -72,13 +72,26 @@ Rather than describing them here, we refer to the following places:
 * minimega settings are provided in both [start-minimega.sh](./start-minimega.sh) and [minimega](./fsroot/etc/default/minimega).
 * miniweb settings are provided in both [start-minimega.sh](./start-minimega.sh).
 
+Currently, the pre-built FIREWHEEL container contains several hard-coded options to work for *most* users.
 The minimega configuration values can be overwritten either by passing environment variables to Docker when starting the container or by binding a file to `/etc/default/minimega` in the container that contains updated values.
 
-> [!NOTE]
-> Currently, the FIREWHEEL configuration options are hard-coded to work with this configuration.
-> Flexibility in setting these values may be provided in a future release.
->  overwritten via Docker environment variables.
+Users can also add an additional layer to the docker container to help adjust these values as needed (see: [docker build variables](https://docs.docker.com/build/building/variables)).
+An example of how to do this is shown below:
 
+```docker
+# This new container enables users to build the container
+# with an alternative minimega files path
+FROM ghcr.io/sandialabs/firewheel:main AS firewheel
+
+# Take in an optional build argument
+ARG MM_FILEPATH=/tmp/minimega/files
+
+RUN echo -e "\nMM_FILEPATH=${MM_FILEPATH}" >> /etc/default/minimega
+
+RUN bash -c "source /fwpy/bin/activate  && \
+    mkdir -p ${MM_FILEPATH} \
+    firewheel config set -s minimega.files_dir ${MM_FILEPATH}"
+```
 
 ## Technical Details
 As with most docker containers, the default user is `root`.

--- a/docker/firewheel.dockerfile
+++ b/docker/firewheel.dockerfile
@@ -95,6 +95,9 @@ RUN bash -c "source /fwpy/bin/activate  && \
 
 RUN firewheel repository install -s -i || { echo "Repository installation failed"; exit 1; }
 
+# Switch SSHD to use 2222 to prevent conflicts with host system
+RUN echo "Port 2222" >> /etc/ssh/sshd_config
+
 RUN cp /usr/bin/sudo /usr/bin/sudo-old && \
     cp /usr/bin/chgrp /usr/bin/chgrp-old
 

--- a/docker/firewheel.dockerfile
+++ b/docker/firewheel.dockerfile
@@ -2,14 +2,27 @@ FROM ghcr.io/sandia-minimega/minimega:master AS minimega
 
 # --#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#-- #
 
-## Package dependencies
-ENV MM_INSTALL_DIR=/opt/minimega
-ENV MINIMEGA_CONFIG=/etc/default/minimega
-ENV MM_BASE=/tmp/minimega
-ENV USER=firewheel
-ENV USER_UID=1001750000
-ENV GRPC_HOSTNAME=localhost
-ENV EXPERIMENT_INTERFACE=lo
+## User Arguments
+ARG USER=firewheel
+ARG USER_UID=1001750000
+
+## Minimega Arguments
+ARG MM_BASE=/tmp/minimega
+ARG MM_RUN_PATH=/tmp/minimega
+ARG MM_FILEPATH=/tmp/minimega/files
+ARG MM_PORT=9000
+ARG MM_DEGREE=1
+ARG MM_CONTEXT=firewheel
+ARG MM_FORCE=true
+ARG MM_LOGLEVEL=debug
+
+## FIREWHEEL Arguments
+ARG GRPC_HOSTNAME=localhost
+ARG EXPERIMENT_INTERFACE=lo
+ARG OUTPUT_DIR=/scratch/firewheel
+ARG LOGGING_ROOT_DIR=/scratch/firewheel
+
+# --#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#-- #
 
 # Install dependencies
 RUN export DEBIAN_FRONTEND=noninteractive && \
@@ -61,15 +74,15 @@ RUN bash -c "python3.10 -m venv /fwpy \
 # Configure Firewheel
 RUN bash -c "source /fwpy/bin/activate  && \
     mkdir -p /var/log/minimega && \
-    mkdir -p /scratch/firewheel && \
-    firewheel config set -s system.default_group $USER && \
-    firewheel config set -s minimega.experiment_interface lo && \
-    firewheel config set -s system.default_output_dir /scratch/firewheel && \
+    mkdir -p ${OUTPUT_DIR} && \
+    firewheel config set -s system.default_group ${USER} && \
+    firewheel config set -s minimega.experiment_interface ${EXPERIMENT_INTERFACE} && \
+    firewheel config set -s system.default_output_dir ${OUTPUT_DIR} && \
     firewheel config set -s minimega.base_dir /tmp/minimega && \
-    firewheel config set -s minimega.files_dir /tmp/minimega/files && \
+    firewheel config set -s minimega.files_dir ${MM_FILEPATH} && \
     firewheel config set -s python.venv /fwpy && \
     firewheel config set -s python.bin python3 && \
-    firewheel config set -s logging.root_dir /scratch/firewheel" \
+    firewheel config set -s logging.root_dir ${LOGGING_ROOT_DIR}" \
     || { echo "Firewheel configuration failed"; exit 1; }
 
 # Set up Bash completion

--- a/docker/firewheel.dockerfile
+++ b/docker/firewheel.dockerfile
@@ -82,6 +82,7 @@ RUN bash -c "source /fwpy/bin/activate  && \
     firewheel config set -s minimega.files_dir ${MM_FILEPATH} && \
     firewheel config set -s python.venv /fwpy && \
     firewheel config set -s python.bin python3 && \
+    firewheel config set -s grpc.hostname ${GRPC_HOSTNAME} && \
     firewheel config set -s logging.root_dir ${LOGGING_ROOT_DIR}" \
     || { echo "Firewheel configuration failed"; exit 1; }
 

--- a/docker/fsroot/usr/local/bin/entry
+++ b/docker/fsroot/usr/local/bin/entry
@@ -32,7 +32,7 @@ export HOME=/root
 
 HN="$(hostname)"
 
-FILEPATH="/tmp/minimega/files"
+FILEPATH="$(firewheel config get minimega.files_dir)"
 mkdir -p $FILEPATH
 
 grn "Starting minimega...       "
@@ -47,7 +47,6 @@ firewheel config set -s cluster.compute "$HN" &>/dev/null
 firewheel config set -s discovery.hostname localhost &>/dev/null
 firewheel config set -s grpc.hostname localhost &>/dev/null
 firewheel config set -s minimega.use_gre True
-firewheel config set -s minimega.files_dir $FILEPATH
 
 firewheel init &>/dev/null
 firewheel sync &>/dev/null

--- a/docker/fsroot/usr/local/bin/entry
+++ b/docker/fsroot/usr/local/bin/entry
@@ -46,7 +46,6 @@ firewheel config set -s cluster.control "$HN" &>/dev/null
 firewheel config set -s cluster.compute "" &>/dev/null
 firewheel config set -s cluster.compute "$HN" &>/dev/null
 firewheel config set -s discovery.hostname localhost &>/dev/null
-firewheel config set -s grpc.hostname localhost &>/dev/null
 firewheel config set -s minimega.use_gre True
 
 firewheel init &>/dev/null

--- a/docker/fsroot/usr/local/bin/entry
+++ b/docker/fsroot/usr/local/bin/entry
@@ -15,7 +15,7 @@ function yl() {
 mkdir /var/run/sshd
 
 # Start the SSH server
-/usr/sbin/sshd
+/usr/sbin/sshd -E /var/log/auth.log
 ssh-keygen -f ~/.ssh/id_rsa -N "" &>/dev/null
 cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 if [ -e ~/.ssh/config ];
@@ -25,6 +25,7 @@ else
     cat << EOF > ~/.ssh/config
 Host *
     StrictHostKeyChecking no
+    Port 2222
 EOF
 fi
 


### PR DESCRIPTION
This PR adds new build parameters that make it easy to modify the creation of a FIREWHEEL docker container and corresponding documentation to help override the default configuration options. Additionally, this moves the docker container to use port 2222 by default as this will prevent conflicts with host systems. This convention is used by other virtualization systems, such as Vagrant. 