### PR TITLE
Refactor the MCPI to deduplicate MCs by absolute path

### DIFF
--- a/src/firewheel/control/model_component_path_iterator.py
+++ b/src/firewheel/control/model_component_path_iterator.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from firewheel.lib.log import Log
 
@@ -12,18 +13,16 @@ class ModelComponentPathIterator:
 
     def __init__(self, repositories):
         """
-        Initialize the class variables and the current position of the iterator.
+        Create an iterator to find model components among a set of MC repos.
 
         Args:
             repositories (list_iterator): The list of repositories.
         """
-        self.repository_iterator = repositories
-
-        self.current_repo = None
-        self.current_repo_components = None
-        self.current_repo_components_position = 0
-
         self.log = Log(name="ModelComponentPathIterator").log
+        self._mc_paths = set()
+        for repo in repositories:
+            repo_mc_paths = self.walk_repository_for_model_component_paths(repo["path"])
+            self._mc_paths.update(repo_mc_paths)
 
     def walk_repository_for_model_component_paths(self, path):
         """
@@ -33,99 +32,56 @@ class ModelComponentPathIterator:
             path (str): Path of the repository.
 
         Returns:
-            list: A list of components contained within the repository.
+            generator: A generator that provides model component paths
+                contained within the repository.
         """
-        if not os.path.exists(path):
+        repo_path = Path(path)
+        if not repo_path.exists():
             self.log.warning(
-                "Unable to locate repository at expected location: %s", path
+                "Unable to locate repository at expected location: %s", repo_path
             )
-            return []
+        return self._recurse_repository(repo_path)
 
-        component_list = self._walk_dir(path)
-        return component_list
-
-    def _walk_dir(self, path):
+    def _recurse_repository(self, path):
         """
-        This is a helper method for `walk_repository_for_model_component_paths()`.
-        It will walk the path and create a recursive list of directories with
+        Recursively search directories for model components.
+
+        This is a helper method for the ``walk_repository_for_model_component_paths()``
+        method. It will walk the path tree to create set of directories within
         the repository which are model components.
 
         Args:
-            path (str): Path of the repository.
+            path (pathlib.Path): Path of the repository.
 
         Returns:
-            list: A list of model component paths contained within the repository.
+            generator: A generator that provides model component paths
+                contained within the repository.
         """
         if self._is_path_model_component(path):
-            return [path]
-
-        ret_list = []
-        for entry in os.listdir(path):
-            if os.path.isdir(os.path.join(path, entry)):
-                ret_list.extend(self._walk_dir(os.path.join(path, entry)))
-        return ret_list
+            yield path.absolute()
+        else:
+            for subdirectory in filter(lambda path: path.is_dir(), path.iterdir()):
+                yield from self._recurse_repository(subdirectory)
 
     def _is_path_model_component(self, path):
         """
         Check to see if the passed-in directory is a model component. The condition for being
-        a model component in this context is if a MANIFEST file exists.
+        a model component in this context is if a ``MANIFEST`` file exists.
 
         Args:
-            path (str): Path of the potential model component.
+            path (pathlib.Path): Path of the potential model component.
 
         Returns:
-            bool: True if a MANIFEST file exists within the directory, False otherwise.
+            bool: py:data:`True` if a MANIFEST file exists within the
+                directory, :py:data:`False` otherwise.
         """
-        # Walk the given repository.
-        for entry in os.listdir(path):
-            # If there is a manifest in this directory, stop walking, we found
-            # a component.
-            if os.path.isfile(os.path.join(path, entry)) and entry == "MANIFEST":
-                return True
-        return False
+        return any(entry.name == "MANIFEST" for entry in path.iterdir())
 
     def __iter__(self):
         return self
 
-    def __next__(self):  # noqa: DOC502
-        """
-        A custom `__next__` method to get the next ModelComponentPathIterator. It resets
-        all the class variables and returns a new instance.
-
-        Returns:
-            ModelComponentPathIterator: The next MCPI with a different repository.
-
-        Raises:
-            StopIteration: If there are no more repositories, this is desired
-                behavior.
-        """
-        if self.current_repo_components is None:
-            # Load the next repository
-            # This should raise StopIteration if there are no more, which is
-            # desired behavior.
-            self.current_repo = next(self.repository_iterator)
-            self.current_repo_components = (
-                self.walk_repository_for_model_component_paths(
-                    self.current_repo["path"]
-                )
-            )
-            self.current_repo_components_position = 0
-
-            # Just use the next repository if there are no components in this
-            # one.
-            if not self.current_repo_components:
-                self.current_repo_components = None
-                return self.__next__()
-            # Fall-through to generic code now that we've set things up again.
-
-        # We have either set up current repo components, or they were already
-        # set up, so work through them to find the next suitable component.
-        for i in range(
-            self.current_repo_components_position, len(self.current_repo_components)
-        ):
-            self.current_repo_components_position += 1
-            return self.current_repo_components[i]
-
-        # We did not find any suitable components, so try the next repo.
-        self.current_repo_components = None
-        return self.__next__()
+    def __next__(self):
+        try:
+            return self._mc_paths.pop()
+        except KeyError:
+            raise StopIteration


### PR DESCRIPTION
This MR refactors the `ModelComponentPathIterator` to rely on a set-based backend that deduplicates MCs as it iterates.

## Background

This solves the duplicate MC errors that were previously seen when a Python package based MC has source code in a repository that has also been installed via `firewheel repository install ...`. 

## Method

This MR gives the `ModelComponentPathIterator` the ability to remember all the paths to all the MCs it has seen (and thus deduplicate them using a `set`). However, because of how we loop over repos in the `firewheel mc list` helper, this MR **does not** fix the fact that duplicate repositories show in that display. That helper creates a new path iterator for each repo, and so they do not know of MCs in other repos. There are probably much more elegant dict-like data structures that could be used to solve this issue, but I wanted to propose the MR first before building anything along those lines.

### Impacts

The current set of changes leaves `ModelComponentPathIterator` largely unchanged from the perspective of a user. (I believe the only change from a user's perspective is that the return values of the `walk_repository_for_model_component_paths` is a generator, not a list.)

### Extra Notes

1. My perspective is that having this `ModelComponentPathIterator` (and the similar `ModelComponentIterator`) objects as an iterator is unnecessarily complicated and provides minimal value. These objects could be dramatically simplified by being _iterables_ (not _iterators_). They could still evaluate lazily, which I think was probably the original intention, they just wouldn't implement the `next(...)` behavior. We don't use it very often, and it seems like it'd be more straightforward for us to just loop over these objects like any other iterable rather than call `next(...)`. Either way, this MR doesn't do any work towards that goal.
2. I would also suggest that we remove the `repository_iterator` attribute, but this is a public attribute so deleting it _could_ be a breaking change. In our codebase(s) it is only ever used internal to the `ModelComponentPathIterator` and this MR removes it from being used even there.