### PR TITLE
fix: Expand docker variables and fix discovery path

### DIFF
--- a/docker/firewheel.dockerfile
+++ b/docker/firewheel.dockerfile
@@ -15,6 +15,7 @@ ARG MM_DEGREE=1
 ARG MM_CONTEXT=firewheel
 ARG MM_FORCE=true
 ARG MM_LOGLEVEL=debug
+ARG MM_LOGFILE=/var/log/minimega.log
 
 ## FIREWHEEL Arguments
 ARG GRPC_HOSTNAME=localhost
@@ -73,12 +74,15 @@ RUN bash -c "python3.10 -m venv /fwpy \
 
 # Configure Firewheel
 RUN bash -c "source /fwpy/bin/activate  && \
-    mkdir -p /var/log/minimega && \
+    mkdir -p ${LOGGING_ROOT_DIR} && \
+    mkdir -p ${MM_FILEPATH} && \
+    mkdir -p ${OUTPUT_DIR}/vm_resource_logs && \
+    mkdir -p ${OUTPUT_DIR}/transfers && \
     mkdir -p ${OUTPUT_DIR} && \
     firewheel config set -s system.default_group ${USER} && \
     firewheel config set -s minimega.experiment_interface ${EXPERIMENT_INTERFACE} && \
     firewheel config set -s system.default_output_dir ${OUTPUT_DIR} && \
-    firewheel config set -s minimega.base_dir /tmp/minimega && \
+    firewheel config set -s minimega.base_dir ${MM_BASE} && \
     firewheel config set -s minimega.files_dir ${MM_FILEPATH} && \
     firewheel config set -s python.venv /fwpy && \
     firewheel config set -s python.bin python3 && \

--- a/docker/firewheel.dockerfile
+++ b/docker/firewheel.dockerfile
@@ -76,9 +76,9 @@ RUN bash -c "python3.10 -m venv /fwpy \
 RUN bash -c "source /fwpy/bin/activate  && \
     mkdir -p ${LOGGING_ROOT_DIR} && \
     mkdir -p ${MM_FILEPATH} && \
+    mkdir -p ${OUTPUT_DIR} && \
     mkdir -p ${OUTPUT_DIR}/vm_resource_logs && \
     mkdir -p ${OUTPUT_DIR}/transfers && \
-    mkdir -p ${OUTPUT_DIR} && \
     firewheel config set -s system.default_group ${USER} && \
     firewheel config set -s minimega.experiment_interface ${EXPERIMENT_INTERFACE} && \
     firewheel config set -s system.default_output_dir ${OUTPUT_DIR} && \

--- a/docker/firewheel.dockerfile
+++ b/docker/firewheel.dockerfile
@@ -49,7 +49,7 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8 && \
 WORKDIR /
 
 # Install discovery
-RUN wget https://github.com/mitchnegus/minimega-discovery/releases/download/firewheel-debian_faed761/discovery.deb && \
+RUN wget https://github.com/sandia-minimega/discovery/releases/download/v0.1.0/discovery.deb && \
     dpkg -i discovery.deb && \
     rm discovery.deb && \
     cd /usr/local/bin && for x in /opt/discovery/bin/*; do echo $x ; ln -s $x .; done \

--- a/docker/fsroot/usr/local/bin/entry
+++ b/docker/fsroot/usr/local/bin/entry
@@ -37,6 +37,16 @@ export HOME=/root
 FILEPATH="$(firewheel config get minimega.files_dir)"
 mkdir -p $FILEPATH
 
+# Verifying extra minimega environment variables
+if [[ -n "${MM_FILEPATH}" ]]; then
+    mkdir -p "${MM_FILEPATH}"
+    firewheel config set -s minimega.files_dir "${MM_FILEPATH}"
+fi
+
+if [[ -n "${MM_BASE}" ]]; then
+    firewheel config set -s minimega.base_dir "${MM_BASE}"
+fi
+
 grn "Starting minimega...       "
 /start-minimega.sh &>/dev/null
 gr "done"


### PR DESCRIPTION
This PR makes the following adjustments to the Docker container:
* Corrects the path to Discovery
* Includes an additional minimega environment variable (`MM_LOGFILE`)
* Removes hardcoded paths with the respective environment variable
* Creates expected paths for log files
* Updates the `firewheel config`  with any minimega environment variables