### PR TITLE
fix: Address issues where minimega environment variables are not passed

### DIFF
--- a/docker/fsroot/start-minimega.sh
+++ b/docker/fsroot/start-minimega.sh
@@ -11,25 +11,39 @@ if pgrep -f "/opt/minimega/bin/minimega" > /dev/null; then
     exit 0
 fi
 
-: "${MINIWEB_ROOT:=/opt/minimega/web}"
-: "${MINIWEB_HOST:=0.0.0.0}"
-: "${MINIWEB_PORT:=9001}"
+# Check if there are values in /etc/default/minimega
+# The order of precedence is:
+# 1. Existing environment variables
+# 2. Variables in /etc/default/minimega
+# 3. A set of defaults in this script
+if [[ -f "/etc/default/minimega" ]]; then
+    # Check if any variables are already set
+    while IFS='=' read -r key value; do
+        # Only set the variable if it is not already set
+        if [[ -z "${!key}" ]]; then
+            export "$key"="$value"
+        fi
+    done < <(grep -v '^#' "/etc/default/minimega")
+fi
 
-: "${MM_BASE:=/tmp/minimega}"
-: "${MM_FILEPATH:=/tmp/minimega/files}"
-: "${MM_BROADCAST:=255.255.255.255}"
-: "${MM_VLANRANGE:=101-4096}"
-: "${MM_PORT:=9000}"
-: "${MM_DEGREE:=1}"
-: "${MM_CONTEXT:=minimega}"
-: "${MM_LOGLEVEL:=debug}"
-: "${MM_LOGFILE:=/var/log/minimega.log}"
-: "${MM_FORCE:=true}"
-: "${MM_RECOVER:=false}"
-: "${MM_CGROUP:=/sys/fs/cgroup}"
-: "${MM_APPEND:=}"
+# Final default assignment (if these are not set already)
+: "${MINIWEB_ROOT:=${MINIWEB_ROOT:-/opt/minimega/web}}"
+: "${MINIWEB_HOST:=${MINIWEB_HOST:-0.0.0.0}}"
+: "${MINIWEB_PORT:=${MINIWEB_PORT:-9001}}"
 
-[[ -f "/etc/default/minimega" ]] && source "/etc/default/minimega"
+: "${MM_BASE:=${MM_BASE:-/tmp/minimega}}"
+: "${MM_FILEPATH:=${MM_FILEPATH:-/tmp/minimega/files}}"
+: "${MM_BROADCAST:=${MM_BROADCAST:-255.255.255.255}}"
+: "${MM_VLANRANGE:=${MM_VLANRANGE:-101-4096}}"
+: "${MM_PORT:=${MM_PORT:-9000}}"
+: "${MM_DEGREE:=${MM_DEGREE:-1}}"
+: "${MM_CONTEXT:=${MM_CONTEXT:-minimega}}"
+: "${MM_LOGLEVEL:=${MM_LOGLEVEL:-debug}}"
+: "${MM_LOGFILE:=${MM_LOGFILE:-/var/log/minimega.log}}"
+: "${MM_FORCE:=${MM_FORCE:-true}}"
+: "${MM_RECOVER:=${MM_RECOVER:-false}}"
+: "${MM_CGROUP:=${MM_CGROUP:-/sys/fs/cgroup}}"
+: "${MM_APPEND:=${MM_APPEND:-}}"
 
 /opt/minimega/bin/miniweb -root=${MINIWEB_ROOT} -addr=${MINIWEB_HOST}:${MINIWEB_PORT} &
 

--- a/src/firewheel/cli/executors/shell.py
+++ b/src/firewheel/cli/executors/shell.py
@@ -68,18 +68,18 @@ class Shell(AbstractExecutor):
             }
 
             # Concatenate minimega environment variables
-            cache_file = " ".join(
+            command = " ".join(
                 f"{env}={os.environ[env]}" for env in minimega_vars if env in os.environ
             )
 
-            cache_file += (
+            command += (
                 f" FIREWHEEL={fw_path} "
                 f"FIREWHEEL_PYTHON={sys.executable} "
                 f"FIREWHEEL_GRPC_SERVER={grpc_path} "
                 f"{cache_file}"
             )
-            cache_file = cache_file.strip()
-            return hosts.run_command(cache_file, session, arguments)
+            command = command.strip()
+            return hosts.run_command(command, session, arguments)
         except IOError as exp:
             print(f"Error: Local I/O error: {exp}")
             self.log.exception("Local I/O error.")

--- a/src/firewheel/cli/executors/shell.py
+++ b/src/firewheel/cli/executors/shell.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from typing import Dict, List, Optional
 from decimal import Decimal
@@ -48,12 +49,36 @@ class Shell(AbstractExecutor):
             hosts = HostAccessor(self.host_list_path)
             fw_path = firewheel.cli.firewheel_cli.__file__
             grpc_path = firewheel.lib.grpc.firewheel_grpc_server.__file__
-            cache_file = (
-                f"FIREWHEEL={fw_path} "
+
+            # We should also pass any environment variables needed for minimega
+            minimega_vars = {
+                "MM_BASE",
+                "MM_FILEPATH",
+                "MM_BROADCAST",
+                "MM_VLANRANGE",
+                "MM_PORT",
+                "MM_DEGREE",
+                "MM_CONTEXT",
+                "MM_LOGLEVEL",
+                "MM_LOGFILE",
+                "MM_FORCE",
+                "MM_RECOVER",
+                "MM_CGROUP",
+                "MM_APPEND"
+            }
+
+            # Concatenate minimega environment variables
+            cache_file = " ".join(
+                f"{env}={os.environ[env]}" for env in minimega_vars if env in os.environ
+            )
+
+            cache_file += (
+                f" FIREWHEEL={fw_path} "
                 f"FIREWHEEL_PYTHON={sys.executable} "
                 f"FIREWHEEL_GRPC_SERVER={grpc_path} "
                 f"{cache_file}"
             )
+            cache_file = cache_file.strip()
             return hosts.run_command(cache_file, session, arguments)
         except IOError as exp:
             print(f"Error: Local I/O error: {exp}")


### PR DESCRIPTION
This PR addresses an issue that is most prevalent in Docker environments, but could impact other experiments as well. We enable users to overwrite minimega configuration values via environment variables. However, our `restart` commands are run via SSH on all nodes (via clustershell). Therefore, these variables must be passed to that remote command much in the same way that we pass the python path and GRPC path. This PR addresses resolves this issue.