### PR TITLE
chore: Remove code for building wheel in favor of CI deployments

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -195,30 +195,6 @@ function check_deps() {
 }
 
 #######################################
-# Basic setup for upgrading the virtual envionment tools and
-# building the FIREWHEEL whl file.
-# Arguments:
-#     None
-# Globals:
-#     PIP_ARGS
-#     PYTHON_BIN
-#######################################
-function install_firewheel_generic() {
-    if ! ${PYTHON_BIN} -m pip install ${PIP_ARGS} build; then
-        err "FIREWHEEL setup failed to pip install 'build'."
-        err "Consult the pip error logs, and verify network connectivity. Aborting."
-        exit 1
-    fi
-
-    if ! ${PYTHON_BIN} -m build; then
-        err "FIREWHEEL setup failed to build the source distribution and wheel."
-        err "Consult the error logs, and verify network connectivity. Aborting."
-        exit 1
-    fi
-
-}
-
-#######################################
 # Installing the FIREWHEEL package with standard dependencies.
 # Arguments:
 #     None
@@ -251,7 +227,6 @@ function install_firewheel() {
 #######################################
 function install_firewheel_development() {
     local clone="$1"
-    install_firewheel_generic
 
     # Install the development version.
     if [[ $clone -eq 0 ]]; then


### PR DESCRIPTION
This removes the call to build a FIREWHEEL package source distribution from the install script. This should no longer be necessary now that FIREWHEEL is either installed directly from PyPI or via an editable install.

For applications where building a source distribution is necessary (e.g., publishing to PyPI), that process should be handled elsewhere—such as in CI job or in a local build workflow.