### PR TITLE
feat: Add a CLI command for getting the configuration path

### DIFF
--- a/src/firewheel/cli/configure_firewheel.py
+++ b/src/firewheel/cli/configure_firewheel.py
@@ -12,6 +12,7 @@ from rich.console import Console
 
 from firewheel.config import Config
 from firewheel.lib.log import Log
+from firewheel.cli.utils import cli_output_theme
 
 
 class ConfigureFirewheel(cmd.Cmd):
@@ -22,6 +23,8 @@ class ConfigureFirewheel(cmd.Cmd):
     """
 
     doc_header = "Get or set the FIREWHEEL configuration using sub-commands:"
+    # Create a class-level console for consistent colored output
+    console = Console(theme=cli_output_theme)
 
     def __init__(self) -> None:
         """Initialize the :py:class:`cmd.Cmd` and the class logger.
@@ -100,9 +103,6 @@ class ConfigureFirewheel(cmd.Cmd):
         Args:
             args (str): A string of arguments passed in by the user.
         """
-        # Create a Console object for colored output
-        console = Console()
-
         # Get the parser for the reset command
         parser = self.define_edit_parser()
         cmd_args = self._handle_parsing(parser, args)
@@ -118,9 +118,9 @@ class ConfigureFirewheel(cmd.Cmd):
         try:
             subprocess.run([editor, Config(writable=True).config_path], check=True)
         except (FileNotFoundError, subprocess.CalledProcessError):
-            console.print(
+            self.console.print(
                 f"Error: Failed to open FIREWHEEL configuration with '{editor}'.\n",
-                style="bold red",
+                style="error",
             )
             self.help_edit()
             return

--- a/src/firewheel/cli/configure_firewheel.py
+++ b/src/firewheel/cli/configure_firewheel.py
@@ -275,6 +275,22 @@ class ConfigureFirewheel(cmd.Cmd):
         else:
             parser.print_help()
 
+    def do_path(self, args: str = "") -> None:
+        """
+        Enable a user to learn the path to the FIREWHEEL configuration file.
+
+        Args:
+            args (str): A string of arguments which are passed in by the user.
+                For this method, the string should be empty.
+        """
+        if args:
+            self.console.print(
+                "Error: The `path` command does not accept arguments.", style="error"
+            )
+            self.help_path()
+        else:
+            print(Config().config_path)
+
     def emptyline(self) -> None:
         """Print help when a blank line is entered.
 
@@ -370,6 +386,18 @@ class ConfigureFirewheel(cmd.Cmd):
     def help_get(self) -> None:
         """Print help for the :py:meth:`do_get` sub-command."""
         print(self._help_get())
+
+    def _help_path(self) -> str:
+        """Help message for the :py:meth`do_path` sub-command.
+
+        Returns:
+            str: The help message.
+        """
+        return "Prints the path to the current FIREWHEEL configuration."
+
+    def help_path(self) -> None:
+        """Print help for the :py:meth:`do_path` sub-command."""
+        print(self._help_path())
 
     def _help_help(self) -> str:
         """Help message for the help sub-command.

--- a/src/firewheel/tests/unit/cli/test_cli_configure.py
+++ b/src/firewheel/tests/unit/cli/test_cli_configure.py
@@ -127,6 +127,17 @@ class CliConfigureTestCase(unittest.TestCase):
 
         self.assertEqual(self.old_config, test_config)
 
+    @unittest.mock.patch("firewheel.cli.configure_firewheel.Config")
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+    def test_do_path(self, mock_stdout, mock_config_cls):
+        mock_config_path = "/path/to/config"
+        mock_config_cls().config_path = mock_config_path
+
+        args = ""
+        self.cli.do_path(args)
+
+        self.assertIn(mock_config_path, mock_stdout.getvalue())
+
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def test_do_edit_param_invalid(self, mock_stdout):
         args = "-e asdf"


### PR DESCRIPTION
This adds a CLI command for getting the path to the FIREWHEEL configuration file.

Example: 
```bash
firewheel config path
> /opt/firewheel/src/firewheel/firewheel.yaml
```