### PR TITLE
ci: Use `config path` command in GitLab CI

### DIFF
--- a/.gitlab/ci/setup.yml
+++ b/.gitlab/ci/setup.yml
@@ -84,7 +84,7 @@ variables:
 .provision_mcs:
   before_script:
     - |
-      sed -i "0,/ansible: {}/s|ansible: {}|ansible:\n    git_servers:\n      - repositories:\n          - path: \"${LINUX_BIN_REPO_PATH}\"\n          - path: \"${DNS_BIN_REPO_PATH}\"\n          - path: \"${VYOS_BIN_REPO_PATH}\"\n          - path: \"${NTP_BIN_REPO_PATH}\"\n          - path: \"${LAYER2_BIN_REPO_PATH}\"\n        server_url: \"https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}\"|" "$(python3 -c 'import firewheel.config; config = firewheel.config.Config(); print(config.config_path)')"
+      sed -i "0,/ansible: {}/s|ansible: {}|ansible:\n    git_servers:\n      - repositories:\n          - path: \"${LINUX_BIN_REPO_PATH}\"\n          - path: \"${DNS_BIN_REPO_PATH}\"\n          - path: \"${VYOS_BIN_REPO_PATH}\"\n          - path: \"${NTP_BIN_REPO_PATH}\"\n          - path: \"${LAYER2_BIN_REPO_PATH}\"\n        server_url: \"https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}\"|" "$(firewheel config path)"
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}/${UTILITIES_BIN_REPO_PATH} /tmp/utilities
     - pushd /tmp/utilities; cp -r --parents * $FIREWHEEL_ROOT_DIR/model_components/firewheel_repo_utilities/; popd;
     - firewheel repository install -i -s


### PR DESCRIPTION
# Use the new command to get the config file path in GitLab CI

## Description
#167 introduces a command to get the path to the FIREWHEEL configuration file. This MR uses that command to get the FIREWHEEL configuration file path in the GitLab CI setup script, rather than using a complicated call to Python.

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [ ] Documentation update
- [x] Other: CI simplification

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [ ] _N/A_ ~I have commented my code, particularly in hard-to-understand areas.~
- [ ]  _N/A_ ~I have made corresponding changes to the documentation.~
- [x] My changes generate no new warnings.
- [x] I have tested my code.