### PR TITLE
ci: Add flexibility to GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ stages:
 performance-ubuntu2204:
   stage: test
   tags:
-    - ubuntu2204
+    - $CI_PERFORMANCE_RUNNER
   needs: []
   variables:
     BASE_PYTHON: python3.10

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,8 @@ performance-ubuntu2204:
   artifacts:
     paths:
       - profile
+  rules:
+    - if: $TEST_FIREWHEEL_PERFORMANCE == "true"
 
 ###############################
 # Create Documentation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ performance-ubuntu2204:
     paths:
       - profile
   rules:
-    - if: $TEST_FIREWHEEL_PERFORMANCE == "true"
+    - if: $FIREWHEEL_TEST_PERFORMANCE == "true"
 
 ###############################
 # Create Documentation
@@ -66,6 +66,8 @@ performance-ubuntu2204:
 docs:
   image: $DOCKER_REGISTRY/python:3.11
   stage: lint
+  tags:
+    - $CI_DOCKER_RUNNER
   needs: []
   before_script:
     - !reference [.create_venv, before_script]
@@ -84,19 +86,17 @@ docs:
   rules:
     - if: $CI_COMMIT_BRANCH =~ /^documentation.*$/
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  tags:
-    - $CI_DOCKER_RUNNER
 
 pages:
   image: $DOCKER_REGISTRY/python:3.11
-  before_script:
-    - echo "Starting pages."
   stage: deploy
   tags:
     - $CI_DOCKER_RUNNER
   needs:
     - job: docs
       artifacts: true
+  before_script:
+    - echo "Starting pages."
   script:
     - mv documentation/html public
   artifacts:
@@ -105,9 +105,19 @@ pages:
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
+###############################
+# Build and Deploy
+#
+# Build FIREWHEEL as a Python package and
+# deploy it to a local package registry
+#
+###############################
 build:
   image: $DOCKER_REGISTRY/python:3.11
   stage: deploy
+  tags:
+    - $CI_DOCKER_RUNNER
+  needs: []
   before_script:
     - apt-get update && apt-get install -y git git-lfs
     - !reference [.create_venv, before_script]
@@ -119,9 +129,6 @@ build:
   artifacts:
     paths:
       - dist/*.whl
-  needs: []
-  tags:
-    - $CI_DOCKER_RUNNER
   rules:
     - if: '$CI_PIPELINE_SOURCE == "release"'
       when: always


### PR DESCRIPTION
# Add flexibility to GitLab CI

## Description
This adds flexibility to the GitLab CI script.

First, it adds a new rule to the performance testing, allowing a GitLab CI/CD environment variable to be used for determining whether or not performance tests should be run. The `FIREHWEEL_TEST_PERFORMANCE` variable can be set to `true` for GitLab instances where performance tests should be run. It can be set to `false` for GitLab instances where performance tests are not desired.

Second, it uses a GitLab CI/CD variable for defining the tags of GitLab runners that should run performance tests. This was previously hardcoded `ubuntu2204`, but it could conceivably be named differently.


## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe): CI/CD improvement

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [ ] _NA_ ~I have commented my code, particularly in hard-to-understand areas.~
- [ ] _NA_ ~I have made corresponding changes to the documentation.~
- [x] My changes generate no new warnings.
- [x] I have tested my code.