### PR TITLE
feat: Confirm before exiting docker container

### DIFF
--- a/docker/fsroot/usr/local/bin/entry
+++ b/docker/fsroot/usr/local/bin/entry
@@ -72,7 +72,16 @@ source /fwpy/bin/activate
 
 if tty -s; then
     if [ "$#" -eq 0 ]; then
-        tmux
+		while true;
+		do
+			tmux
+			read -p "Exit? (yes/no); " response
+			if [[ "$response" == "yes" || "$response" == "y" || $response == "Y" || "$response" == "Yes" ]];
+			then
+				break
+			fi
+		done
+
     else
         # If a command was passed to the container, execute it
         "$@"

--- a/docker/fsroot/usr/local/bin/entry
+++ b/docker/fsroot/usr/local/bin/entry
@@ -74,8 +74,8 @@ if tty -s; then
     if [ "$#" -eq 0 ]; then
 		while true;
 		do
-			tmux
-			read -p "Exit? (yes/no); " response
+			tmux attach 2>/dev/null || tmux
+			read -p "Exit and shutdown container? Your FIREWHEEL experiment will be destroyed (yes/no); " response
 			if [[ "$response" == "yes" || "$response" == "y" || $response == "Y" || "$response" == "Yes" ]];
 			then
 				break


### PR DESCRIPTION
# Confirm before exiting docker container

## Description
In the current version of the docker container, it's very easy to accidentally lose all experiment progress by closing the final tmux pane. This PR changes it so that when the tmux session ends, the user is prompted if they really want to exit the docker container. If they don't choose "yes", it will create a new tmux session.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.