### PR TITLE
chore: Updating all instances of timestamps to use UTC timezone aware datetimes

### DIFF
--- a/src/firewheel/cli/configure_firewheel.py
+++ b/src/firewheel/cli/configure_firewheel.py
@@ -160,7 +160,9 @@ class ConfigureFirewheel(cmd.Cmd):
         try:
             return json.loads(json_string)
         except json.decoder.JSONDecodeError as exc:
-            raise argparse.ArgumentTypeError(f"Invalid JSON string: {json_string}\n\n") from exc
+            raise argparse.ArgumentTypeError(
+                f"Invalid JSON string: {json_string}\n\n"
+            ) from exc
 
     def define_set_parser(self) -> argparse.ArgumentParser:
         """Create an :py:class:`argparse.ArgumentParser` for :ref:`command_config_set`.

--- a/src/firewheel/cli/ssh_manager.py
+++ b/src/firewheel/cli/ssh_manager.py
@@ -112,7 +112,7 @@ class _SSHProtocolManager(ABC):
             (
                 "-o",
                 f"ProxyCommand ssh -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "
-                f"{self.local_hostname} -W %h:%p"
+                f"{self.local_hostname} -W %h:%p",
             ),
         ]
         return options

--- a/src/firewheel/lib/grpc/firewheel_grpc_client.py
+++ b/src/firewheel/lib/grpc/firewheel_grpc_client.py
@@ -1,3 +1,5 @@
+from datetime import timezone
+
 import grpc
 from google.protobuf.timestamp_pb2 import Timestamp  # pylint: disable=no-name-in-module
 
@@ -101,7 +103,11 @@ class FirewheelGrpcClient:
         req = firewheel_grpc_pb2.GetExperimentLaunchTimeRequest(db=self.db)
         try:
             experiment_launch_time = self.stub.GetExperimentLaunchTime(req)
-            experiment_launch_time_dt = experiment_launch_time.launch_time.ToDatetime()
+            experiment_launch_time_dt = (
+                experiment_launch_time.launch_time.ToDatetime().replace(
+                    tzinfo=timezone.utc
+                )
+            )
         except grpc.RpcError as exp:
             if exp.exception().code() != grpc.StatusCode.OUT_OF_RANGE:
                 self.log.exception(exp)
@@ -118,7 +124,11 @@ class FirewheelGrpcClient:
         req = firewheel_grpc_pb2.GetExperimentStartTimeRequest(db=self.db)
         try:
             experiment_start_time = self.stub.GetExperimentStartTime(req)
-            experiment_start_time_dt = experiment_start_time.start_time.ToDatetime()
+            experiment_start_time_dt = (
+                experiment_start_time.start_time.ToDatetime().replace(
+                    tzinfo=timezone.utc
+                )
+            )
         except grpc.RpcError as exp:
             if exp.exception().code() != grpc.StatusCode.OUT_OF_RANGE:
                 self.log.exception(exp)
@@ -141,7 +151,9 @@ class FirewheelGrpcClient:
             launch_time=launch_time_msg, db=self.db
         )
         experiment_launch_time = self.stub.SetExperimentLaunchTime(req)
-        experiment_launch_time_dt = experiment_launch_time.launch_time.ToDatetime()
+        experiment_launch_time_dt = (
+            experiment_launch_time.launch_time.ToDatetime().replace(tzinfo=timezone.utc)
+        )
         return experiment_launch_time_dt
 
     def set_experiment_start_time(self, start_time_dt):
@@ -160,7 +172,9 @@ class FirewheelGrpcClient:
             start_time=start_time_msg, db=self.db
         )
         experiment_start_time = self.stub.SetExperimentStartTime(req)
-        experiment_start_time_dt = experiment_start_time.start_time.ToDatetime()
+        experiment_start_time_dt = (
+            experiment_start_time.start_time.ToDatetime().replace(tzinfo=timezone.utc)
+        )
         return experiment_start_time_dt
 
     def clear_db(self):

--- a/src/firewheel/lib/grpc/firewheel_grpc_server.py
+++ b/src/firewheel/lib/grpc/firewheel_grpc_server.py
@@ -4,7 +4,7 @@ import json
 import time
 import contextlib
 from typing import Iterable
-from datetime import datetime
+from datetime import datetime, timezone
 from concurrent import futures
 from importlib.metadata import version
 
@@ -51,7 +51,7 @@ class FirewheelServicer(firewheel_grpc_pb2_grpc.FirewheelServicer):
         config = Config().get_config()
 
         self.log.info("Initialized FirewheelServicer log.")
-        self.server_start_time = datetime.utcnow()
+        self.server_start_time = datetime.now(timezone.utc)
         self.version = version("firewheel")
         self.cache_dir = os.path.join(
             config["grpc"]["root_dir"], config["grpc"]["cache_dir"]
@@ -135,7 +135,7 @@ class FirewheelServicer(firewheel_grpc_pb2_grpc.FirewheelServicer):
             firewheel_grpc_pb2.GetInfoResponse: The server info.
         """
 
-        uptime = datetime.utcnow() - self.server_start_time
+        uptime = datetime.now(timezone.utc) - self.server_start_time
         uptime = uptime.total_seconds()
 
         experiment_running = bool(

--- a/src/firewheel/vm_resource_manager/experiment_start.py
+++ b/src/firewheel/vm_resource_manager/experiment_start.py
@@ -2,7 +2,7 @@
 Subsystem to determine and report an experiment start time.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 
 from firewheel.config import config
 from firewheel.lib.log import Log
@@ -84,7 +84,7 @@ class ExperimentStart:
         delta = timedelta(
             seconds=int(config["vm_resource_manager"]["experiment_start_buffer_sec"])
         )
-        new_time = datetime.utcnow() + delta
+        new_time = datetime.now(timezone.utc) + delta
         self.grpc_client.set_experiment_start_time(new_time)
 
         return new_time
@@ -111,7 +111,7 @@ class ExperimentStart:
             added to the database: 1-second resolution, UTC.
         """
         # Check to make sure that it isn't already set
-        current_time = datetime.utcnow()
+        current_time = datetime.now(timezone.utc)
         self.grpc_client.set_experiment_launch_time(current_time)
 
         return current_time
@@ -156,7 +156,7 @@ class ExperimentStart:
             int: The time in seconds since when the experiment configured or
             None if experiment hasn't started yet.
         """
-        current_time = datetime.utcnow()
+        current_time = datetime.now(timezone.utc)
         start_time = self.get_start_time()
         if not start_time:
             return None

--- a/src/firewheel/vm_resource_manager/vm_resource_handler.py
+++ b/src/firewheel/vm_resource_manager/vm_resource_handler.py
@@ -18,7 +18,7 @@ import contextlib
 import importlib.util
 from queue import Queue, PriorityQueue
 from pathlib import Path, PureWindowsPath
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from threading import Timer, Thread, Condition
 
 from firewheel.config import config as global_config
@@ -312,7 +312,7 @@ class VMResourceHandler:
                             seconds=schedule_entry.start_time
                         )
 
-                        curtime = datetime.utcnow()
+                        curtime = datetime.now(timezone.utc)
                         delay = (runtime - curtime).total_seconds()
                         start_seconds = (
                             self.experiment_start_time - curtime
@@ -358,7 +358,7 @@ class VMResourceHandler:
                             seconds=schedule_entry.start_time
                         )
 
-                        curtime = datetime.utcnow()
+                        curtime = datetime.now(timezone.utc)
                         delay = (runtime - curtime).total_seconds()
                         start_seconds = (
                             self.experiment_start_time - curtime
@@ -748,7 +748,9 @@ class VMResourceHandler:
         if isinstance(content, dict):
             try:
                 # Only log a line if it is a JSON object.
-                content["timestamp"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                content["timestamp"] = datetime.now(timezone.utc).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
                 self.json_log.info(json.dumps(content))
             except TypeError:
                 self.log.debug("Could not parse '%s' into JSON formatting.", content)
@@ -762,12 +764,16 @@ class VMResourceHandler:
                 # Only log a line if it can be decoded
                 try:
                     data = json.loads(line.decode())
-                    data["timestamp"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                    data["timestamp"] = datetime.now(timezone.utc).strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
                 except (json.JSONDecodeError, TypeError):
                     try:
                         # Convert decoded line into a dict
                         data = {"msg": line.decode()}
-                        data["timestamp"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                        data["timestamp"] = datetime.now(timezone.utc).strftime(
+                            "%Y-%m-%d %H:%M:%S"
+                        )
                     except TypeError:
                         return
                 self.json_log.info(json.dumps(data))


### PR DESCRIPTION
# Updating all instances of timestamps to use UTC timezone aware datetimes

## Description
The `utcnow()` method has been deprecated for a while and while fixing/updating this, I addressed a few other places where we do not use UTC Timezone-aware objects. 

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe): chore

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.