### PR TITLE
feat: Enhance progress outputs for image cache uploads

### DIFF
--- a/src/firewheel/control/model_component.py
+++ b/src/firewheel/control/model_component.py
@@ -509,9 +509,7 @@ class ModelComponent:
         Upload all image files from the manifest.
 
         Returns:
-            list: Actions for each specified file. Order is sequential,
-            proceeding through images, for each image proceed through each
-            specified file before moving to next image. Possible actions are:
+            dict: Actions for each specified file. Possible actions are:
 
             * ``no_date`` -- There was no upload date for the given file in the
                   ``ImageStore``. It was uploaded.
@@ -524,14 +522,14 @@ class ModelComponent:
             * :py:data:`False` -- None of the other conditions occurred. For example,
                   the file on disk was modified before the ``ImageStore`` upload time.
 
-            An empty list is returned if no images are identified.
+            An empty dictionary is returned if no images are identified.
 
         """
-        return [
-            self._upload_image(image_path)
+        return {
+            image_path: self._upload_image(image_path)
             for image_field in self.manifest.get("images", {})
             for image_path in image_field.get("paths", [])
-        ]
+        }
 
     def _upload_image(self, image_path):
         """

--- a/src/firewheel/control/model_component.py
+++ b/src/firewheel/control/model_component.py
@@ -400,7 +400,8 @@ class ModelComponent:
 
     def _upload_vm_resource(self, resource):
         """
-        Upload a file to the ``VmResourceStore``.
+        Upload a file to the :py:class:`VmResourceStore
+        <firewheel.vm_resource_manager.vm_resource_store.VmResourceStore>`.
         It interrupts the path of the VM resources in the following way:
 
         * Non-recursive all dir's files: ``path_to_dir``,
@@ -537,15 +538,17 @@ class ModelComponent:
             dict: Statuses for each specified file. Possible statuses are:
 
             * ``no_date`` -- There was no upload date for the given file in the
-                  ``ImageStore``. It was uploaded.
+                  :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`.
+                  It was uploaded.
             * ``new_hash`` -- The modified time of the file on disk differs from the
-                  last upload time in the ``ImageStore`` and the hashes did not match.
-                  File was uploaded.
+                  last upload time in the :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`
+                  and the hashes did not match. File was uploaded.
             * ``same_hash`` -- The file on disk was modified after the upload time in
-                  the ``ImageStore`` but the hashes are the same. File was
-                  not uploaded.
+                  the :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`
+                  but the hashes are the same. File was not uploaded.
             * :py:data:`False` -- None of the other conditions occurred. For example,
-                  the file on disk was modified before the ``ImageStore`` upload time.
+                  the file on disk was modified before the :py:class:`ImageStore
+                  <firewheel.control.image_store.ImageStore>` upload time.
 
             An empty dictionary is returned if no images are identified.
 
@@ -567,7 +570,10 @@ class ModelComponent:
 
     def _evaluate_image(self, image_path):
         """
-        Evaluate an image's status (governing uploads to the ``ImageStore``).
+        Evaluate an image's status.
+
+        Perform an evaluation of the image's status. The result will govern
+        uploads to the :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`).
 
         Args:
             image_path (str): A path to an image to be evaluated.
@@ -576,13 +582,16 @@ class ModelComponent:
             str: A status for the specified image file. Possible statuses are:
 
             * ``no_date`` -- There was no upload date for the given file in the
-                  ``ImageStore``.
+                  :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`.
             * ``new_hash`` -- The modified time of the file on disk differs from the
-                  last upload time in the ``ImageStore`` and the hashes did not match.
+                  last upload time in the :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`
+                  and the hashes did not match.
             * ``same_hash`` -- The file on disk was modified after the upload time in
-                  the ``ImageStore`` but the hashes are the same.
+                  the :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`
+                  but the hashes are the same.
             * :py:data:`False` -- None of the other conditions occurred. For example,
-                  the file on disk was modified before the ``ImageStore`` upload time.
+                  the file on disk was modified before the :py:class:`ImageStore
+                  <firewheel.control.image_store.ImageStore>` upload time.
         """
         path = Path(self.path, image_path)
         self._verify_image_exists(path)
@@ -609,10 +618,14 @@ class ModelComponent:
 
     def _upload_image(self, image_path, action="Adding"):
         """
-        Upload an image to the ``ImageStore`` based on the image's status.
+        Upload an image to the `ImageStore <firewheel.control.image_store.ImageStore>`.
+
+        Inspect the status of the image status and perform an upload to the
+        `ImageStore <firewheel.control.image_store.ImageStore>` accordingly.
 
         Args:
-            image_path (str): A path to an image to be added to the ``ImageStore``.
+            image_path (str): A path to an image to be added to the `ImageStore
+            <firewheel.control.image_store.ImageStore>`.
             action (str): The action being performed on the image.
         """
         update_cache_task_id = self.image_cache_progress.add_task(

--- a/src/firewheel/control/model_component.py
+++ b/src/firewheel/control/model_component.py
@@ -33,6 +33,12 @@ class ModelComponent:
     for FIREWHEEL experiments.
     """
 
+    # Default databases and file stores are common to all model components
+    # and have nontrivial instantiation times (only instantiate them once)
+    _default_repository_db = RepositoryDb()
+    _default_vm_resource_store = VmResourceStore()
+    _default_image_store = ImageStore()
+
     def __init__(
         self,
         name=None,
@@ -83,12 +89,9 @@ class ModelComponent:
         self.path = path
         self._install = install
 
-        if repository_db is not None:
-            self.repository_db = repository_db
-        if vm_resource_store is not None:
-            self.vm_resource_store = vm_resource_store
-        if image_store is not None:
-            self.image_store = image_store
+        self.repository_db = repository_db or self._default_repository_db
+        self.vm_resource_store = vm_resource_store or self._default_vm_resource_store
+        self.image_store = image_store or self._default_image_store
 
         if self.name is None and self.path is None:
             raise ValueError("Must specify at least name or path.")
@@ -138,72 +141,6 @@ class ModelComponent:
         self.image_cache_progress_group = Group(
             self.overall_image_cache_progress, self.image_cache_progress
         )
-
-    @property
-    def repository_db(self):
-        """
-        Use the specified :class:`RepositoryDb`.
-
-        Returns:
-            RepositoryDb: The specified repository database.
-        """
-        try:
-            if self._repository_db is None:
-                # pylint: disable=attribute-defined-outside-init
-                self._repository_db = RepositoryDb()
-        except AttributeError:
-            # pylint: disable=attribute-defined-outside-init
-            self._repository_db = RepositoryDb()
-        return self._repository_db
-
-    @repository_db.setter
-    def repository_db(self, value):
-        # pylint: disable=attribute-defined-outside-init
-        self._repository_db = value
-
-    @property
-    def vm_resource_store(self):
-        """
-        Use the specified :class:`VmResourceStore`.
-
-        Returns:
-            VmResourceStore: The specified resource store.
-        """
-        try:
-            if self._vm_resource_store is None:
-                # pylint: disable=attribute-defined-outside-init
-                self._vm_resource_store = VmResourceStore()
-        except AttributeError:
-            # pylint: disable=attribute-defined-outside-init
-            self._vm_resource_store = VmResourceStore()
-        return self._vm_resource_store
-
-    @vm_resource_store.setter
-    def vm_resource_store(self, value):
-        # pylint: disable=attribute-defined-outside-init
-        self._vm_resource_store = value
-
-    @property
-    def image_store(self):
-        """
-        Use the specified :class:`ImageStore`.
-
-        Returns:
-            ImageStore: The specified :class:`ImageStore`.
-        """
-        try:
-            if self._image_store is None:
-                # pylint: disable=attribute-defined-outside-init
-                self._image_store = ImageStore()
-        except AttributeError:
-            # pylint: disable=attribute-defined-outside-init
-            self._image_store = ImageStore()
-        return self._image_store
-
-    @image_store.setter
-    def image_store(self, value):
-        # pylint: disable=attribute-defined-outside-init
-        self._image_store = value
 
     def _load_manifest(self, path):
         """

--- a/src/firewheel/control/model_component.py
+++ b/src/firewheel/control/model_component.py
@@ -449,7 +449,7 @@ class ModelComponent:
             return "no_date"
 
         if modification_timestamp != upload_date:
-            self.log.debug("Resource on disk is different from store. Checksuming.")
+            self.log.debug("Resource on disk is different from store. Checksumming.")
             resource_hash = hash_file(path)
             store_hash = self.vm_resource_store.get_file_hash(resource)
             self.log.debug(

--- a/src/firewheel/control/model_component.py
+++ b/src/firewheel/control/model_component.py
@@ -4,7 +4,15 @@ from pathlib import Path
 from datetime import datetime, timezone
 
 import yaml
-from rich.progress import Progress, TextColumn, SpinnerColumn, TimeElapsedColumn
+from rich.live import Live
+from rich.console import Group
+from rich.progress import (
+    Progress,
+    TextColumn,
+    SpinnerColumn,
+    TimeElapsedColumn,
+    MofNCompleteColumn,
+)
 
 from firewheel.lib.log import Log
 from firewheel.lib.utilities import hash_file
@@ -113,6 +121,23 @@ class ModelComponent:
                 )
             self.arguments = arguments
         self.log = Log(name="ModelComponent").log
+
+        # Set progress bars for this MC
+        self.overall_image_cache_progress = Progress(
+            MofNCompleteColumn(),
+            SpinnerColumn(spinner_name="line"),
+            TextColumn(
+                "[yellow]Populating/refreshing the image cache for MC "
+                f"`[white]{name}`[/white]. This may take a while..."
+            ),
+        )
+        self.image_cache_progress = Progress(
+            TimeElapsedColumn(),
+            TextColumn("[yellow]- {task.description}"),
+        )
+        self.image_cache_progress_group = Group(
+            self.overall_image_cache_progress, self.image_cache_progress
+        )
 
     @property
     def repository_db(self):
@@ -530,15 +555,14 @@ class ModelComponent:
             for image_field in self.manifest.get("images", {})
             for image_path in image_field.get("paths", [])
         }
-        # Filter images that require uploads (and upload them)
-        upload_images = {
-            image_path: status
-            for image_path, status in image_statuses.items()
-            if status in {"no_date", "new_hash"}
-        }
-        if upload_images:
-            for image_path, status in upload_images.items():
-                self._upload_image(image_path, status)
+        if image_actions := self._determine_image_actions(image_statuses):
+            with Live(self.image_cache_progress_group):
+                overall_task_id = self.overall_image_cache_progress.add_task(
+                    "", total=len(image_actions)
+                )
+                for image_path, action in image_actions.items():
+                    self._upload_image(image_path, action=action)
+                    self.overall_image_cache_progress.update(overall_task_id, advance=1)
         return image_statuses
 
     def _evaluate_image(self, image_path):
@@ -575,37 +599,27 @@ class ModelComponent:
             return "same_hash" if disk_hash == store_hash else "new_hash"
         return False
 
-    def _upload_image(self, image_path, status):
+    def _determine_image_actions(self, image_statuses):
+        # Determine (and filter) images that require uploads
+        return {
+            image_path: "Adding" if status == "no_date" else "Updating"
+            for image_path, status in image_statuses.items()
+            if status in {"no_date", "new_hash"}
+        }
+
+    def _upload_image(self, image_path, action="Adding"):
         """
         Upload an image to the ``ImageStore`` based on the image's status.
 
         Args:
             image_path (str): A path to an image to be added to the ``ImageStore``.
-            status (str): The status of the image which determines how it will be
-                uploaded.
+            action (str): The action being performed on the image.
         """
-        path = Path(self.path, image_path)
-
-        if status == "no_date":
-            with Progress(
-                TextColumn(
-                    f"[yellow]Adding {image_path} to cache. This may take a while."
-                ),
-                SpinnerColumn(spinner_name="line"),
-                TimeElapsedColumn(),
-            ) as progress:
-                progress.add_task(description="upload_image")
-                self.image_store.add_image_file(path)
-        elif status == "new_hash":
-            with Progress(
-                TextColumn(
-                    f"[yellow]Updating {image_path} in cache. This may take a while."
-                ),
-                SpinnerColumn(spinner_name="line"),
-                TimeElapsedColumn(),
-            ) as progress:
-                progress.add_task(description="upload_image")
-            self.image_store.add_image_file(path)
+        update_cache_task_id = self.image_cache_progress.add_task(
+            description=f"{action} {image_path}"
+        )
+        self.image_store.add_image_file(Path(self.path, image_path))
+        self.image_cache_progress.stop_task(update_cache_task_id)
 
     @staticmethod
     def _verify_vmr_exists(vmr_path):

--- a/src/firewheel/control/model_component.py
+++ b/src/firewheel/control/model_component.py
@@ -1,7 +1,11 @@
 import os
+import enum
 import pprint
+import warnings
+from abc import ABC, abstractmethod
 from pathlib import Path
 from datetime import datetime, timezone
+from itertools import chain
 
 import yaml
 from rich.live import Live
@@ -25,6 +29,126 @@ from firewheel.control.model_component_exceptions import (
 )
 from firewheel.control.model_component_path_iterator import ModelComponentPathIterator
 from firewheel.vm_resource_manager.vm_resource_store import VmResourceStore
+
+
+class _ModelComponentFile(ABC):
+    """An abstract base class representing a generic (cacheable) file object."""
+
+    def __init__(self, path, file_store):
+        """
+        Instantiate the object representing a binary file.
+
+        Args:
+            path (pathlib.Path): The path to the binary file.
+            file_store (firewheel.lib.minimega.file_store.FileStore): A
+                file store object that will serve as the destination for
+                the file.
+
+        Notes:
+            This class is similar to the :py:class:`lib.minimega.file_store.FileStoreFile`
+            but represents a file at a different point in its lifetime. Where that
+            object provides an interface to an object that should already be present
+            in a file store, this object provides an interface for a file specified
+            in a model component that may or may not have already been uploaded to
+            a file store. These two interfaces may ultimately be merged.
+        """
+        self.path = path
+        self.file_store = file_store
+        self.file_store_status = None
+        self._verify_existence()
+
+    @property
+    def name(self):
+        return self.path.name
+
+    @property
+    def size(self):
+        # Size of the file in bytes
+        return self.path.stat().st_size
+
+    @property
+    def modification_timestamp(self):
+        return datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+
+    @property
+    def requires_upload(self):
+        self.update_file_store_status()
+        return self.file_store_status in (
+            _FileStoreStatus.MISSING,
+            _FileStoreStatus.OUTDATED,
+        )
+
+    def _verify_existence(self):
+        if not self.path.exists():
+            self._handle_missing_file()
+
+    @abstractmethod
+    def _handle_missing_file(self):
+        raise NotImplementedError
+
+    def _determine_file_store_status(self):
+        # Exit immediately if the file appears to be missing
+        if (store_timestamp := self.file_store.get_file_upload_date(self.name)) is None:
+            return _FileStoreStatus.MISSING
+        # The file exists in the store; compare the two files
+        if store_timestamp == self.modification_timestamp:
+            # Exceedingly unlikely that two different files have identical timestamps;
+            # exit quickly without checking hashes
+            return _FileStoreStatus.CURRENT
+        # Hash files as a comparison
+        # (typically faster than assuming outdated and triggering a reupload)
+        store_hash = self.file_store.get_file_hash(self.name)
+        binary_hash = hash_file(self.path)
+        if store_hash and store_hash == binary_hash:
+            return _FileStoreStatus.CURRENT
+        if store_timestamp < self.modification_timestamp:
+            return _FileStoreStatus.OUTDATED
+        warnings.warn(
+            f"Cached file `{self.name}` appears to be out-of-sync with "
+            f"the MC-provided copy (`{self.path}`) ",
+            stacklevel=2,
+        )
+        return _FileStoreStatus.UNKNOWN
+
+    def update_file_store_status(self):
+        """Update the binary's status based on its availability in the file store."""
+        self.file_store_status = self._determine_file_store_status()
+
+    def upload(self):
+        """Upload the binary file to the file store."""
+        self.file_store.add_file(self.path)
+
+
+class _Image(_ModelComponentFile):
+    """A binary file object representing a VM image."""
+
+    def _handle_missing_file(self):
+        # The image does not exist. This is a problem... unless the image is already
+        # in the file store then it may or may not be an issue. Either way, it is
+        # weird and the user should fix it.
+        raise MissingImageError(
+            f"The image {self.path} is not present in the model component."
+        )
+
+    def upload(self):
+        """Upload the binary file to the file store."""
+        self.file_store.add_image_file(self.path)
+
+
+class _VMResource(_ModelComponentFile):
+    """A binary file object representing a VM resource."""
+
+    def _handle_missing_file(self):
+        raise MissingVmResourceError(self.path)
+
+
+class _FileStoreStatus(enum.Enum):
+    """An enumeration of file statuses that may be assigned to files in a file store."""
+
+    CURRENT = enum.auto()
+    OUTDATED = enum.auto()
+    MISSING = enum.auto()
+    UNKNOWN = enum.auto()
 
 
 class ModelComponent:
@@ -126,20 +250,20 @@ class ModelComponent:
         self.log = Log(name="ModelComponent").log
 
         # Set progress bars for this MC
-        self.overall_image_cache_progress = Progress(
+        self.overall_cache_progress = Progress(
             MofNCompleteColumn(),
             SpinnerColumn(spinner_name="line"),
             TextColumn(
-                "[yellow]Populating/refreshing the image cache for MC "
-                f"`[white]{name}`[/white]. This may take a while..."
+                "[yellow]Populating/refreshing large files in the cache for MC "
+                f"`[white]{self.name}`[/white]. This may take a while..."
             ),
         )
-        self.image_cache_progress = Progress(
+        self.large_file_cache_progress = Progress(
             TimeElapsedColumn(),
             TextColumn("[yellow]- {task.description}"),
         )
-        self.image_cache_progress_group = Group(
-            self.overall_image_cache_progress, self.image_cache_progress
+        self.cache_progress_group = Group(
+            self.overall_cache_progress, self.large_file_cache_progress
         )
 
     def _load_manifest(self, path):
@@ -332,281 +456,122 @@ class ModelComponent:
         """
         Upload any VM Resources and Images needed for the experiment to the cache.
         """
-        self._upload_vm_resources()
-        self._upload_images()
+        threshold = 250_000_000  # 25 MB
+        vm_resources = self._collect_vm_resources()
+        images = self._collect_images()
+        # Upload small files silently
+        small_vmr_uploads = [
+            vmr for vmr in vm_resources if vmr.requires_upload and vmr.size <= threshold
+        ]
+        self._upload_small_files(small_vmr_uploads)
+        # Use progress displays for large file uploads
+        large_vmr_uploads = [
+            vmr for vmr in vm_resources if vmr.requires_upload and vmr.size > threshold
+        ]
+        image_uploads = [image for image in images if image.requires_upload]
+        if large_file_uploads := large_vmr_uploads + image_uploads:
+            self._upload_large_files(large_file_uploads)
 
-    def _upload_vm_resource(self, resource):
-        """
-        Upload a file to the :py:class:`VmResourceStore
-        <firewheel.vm_resource_manager.vm_resource_store.VmResourceStore>`.
-        It interrupts the path of the VM resources in the following way:
+    def _upload_small_files(self, files):
+        for file in files:
+            file.upload()
 
-        * Non-recursive all dir's files: ``path_to_dir``,
-          ``path_to_dir/``, or ``path_to_dir/*``
-        * Non-recursive all dir's files matching pattern: ``path_to_dir/*.ext``
-        * Recursive all files: ``path_to_dir/**``, ``path_to_dir/**/``, or
-          ``path_to_dir/**/*``
-        * Recursive  all files matching pattern: ``path_to_dir/**/*.ext``
+    def _upload_large_files(self, files):
+        with Live(self.cache_progress_group):
+            overall_task_id = self.overall_cache_progress.add_task("", total=len(files))
+            for file in files:
+                self._upload_large_file(file)
+                self.overall_cache_progress.update(overall_task_id, advance=1)
 
-        Args:
-            resource (str): Path relative to this component's root to the file being
-                            uploaded.
-
-        Returns:
-            str: Indication of what happened. This may be one of:
-                ``no_date`` -- There was no upload date for the given file in the
-                    ``VmResourceStore``. It was uploaded.
-                ``new_hash`` -- The modified time of the file on disk differs from the
-                    last upload time in the ``VmResourceStore`` and the hashes did not
-                    match. File was uploaded.
-                ``same_hash`` -- The file on disk was modified after the upload time in
-                    the ``VmResourceStore`` but the hashes are the same. File was not
-                    uploaded.
-                :py:data:`False` -- None of the other conditions occurred. For example,
-                    the file on disk was modified before the ``VmResourceStore`` upload
-                    time.
-        """
-        path = Path(self.path, resource)
-        self._verify_vmr_exists(path)
-
-        modification_timestamp = self._get_modification_timestamp(path)
-        self.log.debug(
-            "Resource %s in %s has modified time of %s",
-            resource,
-            self.manifest["name"],
-            modification_timestamp,
+    def _upload_large_file(self, file):
+        # Upload a large file to the cache, including progress displays
+        is_outdated = file.file_store_status == _FileStoreStatus.OUTDATED
+        action = "Updating" if is_outdated else "Adding"
+        update_cache_task_id = self.large_file_cache_progress.add_task(
+            description=f"{action} file: `{file.name}`"
         )
-        upload_date = self.vm_resource_store.get_file_upload_date(Path(resource).name)
-        self.log.debug("VM Resource store file has upload date of %s", upload_date)
+        file.upload()
+        self.large_file_cache_progress.stop_task(update_cache_task_id)
 
-        if upload_date is None:
-            self.log.debug(
-                "Resource %s not found in store. Uploading.", os.path.basename(resource)
-            )
-            self.vm_resource_store.add_file(path)
-            return "no_date"
-
-        if modification_timestamp != upload_date:
-            self.log.debug("Resource on disk is different from store. Checksumming.")
-            resource_hash = hash_file(path)
-            store_hash = self.vm_resource_store.get_file_hash(resource)
-            self.log.debug(
-                "Resource %s//%s on disk has hash %s and in store has %s",
-                self.manifest["name"],
-                resource,
-                resource_hash,
-                store_hash,
-            )
-
-            if resource_hash != store_hash:
-                self.log.debug("Newer resource checksum differs. Uploading.")
-                self.vm_resource_store.add_file(path)
-                return "new_hash"
-            return "same_hash"
-        return False
-
-    def _upload_vm_resources(self):
+    def _collect_vm_resources(self):
         """
-        Upload all VM resources from the manifest. It interrupts the path
-        of the VM resources in the following way:
-
-        * Non-recursive all dir's files: ``path_to_dir``,
-          ``path_to_dir/``, or ``path_to_dir/*``
-        * Non-recursive all dir's files matching pattern: ``path_to_dir/*.ext``
-        * Recursive all files: ``path_to_dir/**``, ``path_to_dir/**/``, or
-          ``path_to_dir/**/*``
-        * Recursive  all files matching pattern: ``path_to_dir/**/*.ext``
+        Collect all VM resources from the manifest.
 
         Returns:
-            bool: :py:data:`True` if any resource was uploaded, :py:data:`False`
-                otherwise.
+            list: A list of VM resource objects determined from the manifest.
 
         Raises:
             RuntimeError: If the ``vm_resources`` field in the MANIFEST is not a list.
         """
-        if (vm_resources := self.manifest.get("vm_resources")) is None:
-            return False
-        elif not isinstance(vm_resources, list):
+        vm_resource_list = self.manifest.get("vm_resources", [])
+
+        if not isinstance(vm_resource_list, list):
             # The `vm_resources` must be in a list
             raise RuntimeError(
-                'Malformed MANIFEST, the "vm_resources" attribute must be a list. '
-                f"It is currently: `{vm_resources}` of type `{type(vm_resources)}`."
+                "Malformed MANIFEST, the `vm_resources` attribute must be a list. "
+                f"It is currently: `{vm_resource_list}` of type "
+                f"`{type(vm_resource_list)}`."
             )
 
-        any_uploaded = False
-
-        # Interpret path as follows:
-        # Non-recursive, all dir's files, non-recursive: path_to_dir, path_to_dir/ -> path_to_dir/*
-        # Non-recursive, all dir's files matching pattern path_to_dir/*.ext -> no change
-        # Recursive - all files: path_to_dir/**, path_to_dir/**/ -> path_to_dir/**/*
-        # Recursive - all files matching pattern: path_to_dir/**/*.ext -> no change
-        for manifest_vm_resource in vm_resources:
-            if Path(self.path).joinpath(manifest_vm_resource).is_dir():
-                manifest_vm_resource += "/*"
-
-            # replace all ** not already followed by **/* with **/*
-            manifest_vm_resource = manifest_vm_resource.replace("**/*", "**")
-            manifest_vm_resource = manifest_vm_resource.replace("**", "**/*")
-            if "*" in manifest_vm_resource:
-                enumerated_resources = [
-                    str(p.relative_to(self.path))
-                    for p in Path(self.path).glob(manifest_vm_resource)
-                    if p.is_file()
-                ]
-            else:
-                enumerated_resources = [manifest_vm_resource]
-            for resource in enumerated_resources:
-                self.log.debug(
-                    "Uploading resource %s from model component %s",
-                    resource,
-                    self.manifest["name"],
-                )
-                result = self._upload_vm_resource(resource)
-                if result == "same_hash":
-                    result = False
-                any_uploaded = any_uploaded or bool(result)
-        return any_uploaded
-
-    def _upload_images(self):
-        """
-        Upload all image files from the manifest.
-
-        Returns:
-            dict: Statuses for each specified file. Possible statuses are:
-
-            * ``no_date`` -- There was no upload date for the given file in the
-                  :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`.
-                  It was uploaded.
-            * ``new_hash`` -- The modified time of the file on disk differs from the
-                  last upload time in the :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`
-                  and the hashes did not match. File was uploaded.
-            * ``same_hash`` -- The file on disk was modified after the upload time in
-                  the :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`
-                  but the hashes are the same. File was not uploaded.
-            * :py:data:`False` -- None of the other conditions occurred. For example,
-                  the file on disk was modified before the :py:class:`ImageStore
-                  <firewheel.control.image_store.ImageStore>` upload time.
-
-            An empty dictionary is returned if no images are identified.
-
-        """
-        image_statuses = {
-            image_path: self._evaluate_image(image_path)
-            for image_field in self.manifest.get("images", {})
-            for image_path in image_field.get("paths", [])
-        }
-        if image_actions := self._determine_image_actions(image_statuses):
-            with Live(self.image_cache_progress_group):
-                overall_task_id = self.overall_image_cache_progress.add_task(
-                    "", total=len(image_actions)
-                )
-                for image_path, action in image_actions.items():
-                    self._upload_image(image_path, action=action)
-                    self.overall_image_cache_progress.update(overall_task_id, advance=1)
-        return image_statuses
-
-    def _evaluate_image(self, image_path):
-        """
-        Evaluate an image's status.
-
-        Perform an evaluation of the image's status. The result will govern
-        uploads to the :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`).
-
-        Args:
-            image_path (str): A path to an image to be evaluated.
-
-        Returns:
-            str: A status for the specified image file. Possible statuses are:
-
-            * ``no_date`` -- There was no upload date for the given file in the
-                  :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`.
-            * ``new_hash`` -- The modified time of the file on disk differs from the
-                  last upload time in the :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`
-                  and the hashes did not match.
-            * ``same_hash`` -- The file on disk was modified after the upload time in
-                  the :py:class:`ImageStore <firewheel.control.image_store.ImageStore>`
-                  but the hashes are the same.
-            * :py:data:`False` -- None of the other conditions occurred. For example,
-                  the file on disk was modified before the :py:class:`ImageStore
-                  <firewheel.control.image_store.ImageStore>` upload time.
-        """
-        path = Path(self.path, image_path)
-        self._verify_image_exists(path)
-
-        modification_timestamp = self._get_modification_timestamp(path)
-        upload_date = self.image_store.get_file_upload_date(path.name)
-
-        if upload_date is None:
-            return "no_date"
-        elif modification_timestamp != upload_date:
-            # The timestamps do not match; compare the hashes
-            disk_hash = hash_file(path)
-            store_hash = self.image_store.get_file_hash(os.path.basename(path))
-            return "same_hash" if disk_hash == store_hash else "new_hash"
-        return False
-
-    def _determine_image_actions(self, image_statuses):
-        # Determine (and filter) images that require uploads
-        return {
-            image_path: "Adding" if status == "no_date" else "Updating"
-            for image_path, status in image_statuses.items()
-            if status in {"no_date", "new_hash"}
-        }
-
-    def _upload_image(self, image_path, action="Adding"):
-        """
-        Upload an image to the `ImageStore <firewheel.control.image_store.ImageStore>`.
-
-        Inspect the status of the image status and perform an upload to the
-        `ImageStore <firewheel.control.image_store.ImageStore>` accordingly.
-
-        Args:
-            image_path (str): A path to an image to be added to the `ImageStore
-            <firewheel.control.image_store.ImageStore>`.
-            action (str): The action being performed on the image.
-        """
-        update_cache_task_id = self.image_cache_progress.add_task(
-            description=f"{action} {image_path}"
+        vm_resource_names = chain.from_iterable(
+            self._interpret_manifest_vmr_specification(manifest_vm_resource)
+            for manifest_vm_resource in vm_resource_list
         )
-        self.image_store.add_image_file(Path(self.path, image_path))
-        self.image_cache_progress.stop_task(update_cache_task_id)
+        return [
+            _VMResource(Path(self.path, vmr_name), self.vm_resource_store)
+            for vmr_name in vm_resource_names
+        ]
 
-    @staticmethod
-    def _verify_vmr_exists(vmr_path):
+    def _interpret_manifest_vmr_specification(self, manifest_vm_resource):
         """
-        Verify that the VM resource exists in the model component.
+        Interpret a specified VM resource string provided in a manifest file.
 
         Args:
-            vmr_path (path): The path to the VM resource to verify.
+            manifest_vm_resource (str): A string specifyin a VM resource, VM
+                resource directory, or collection of VM resources according to
+                a pattern.
 
-        Raises:
-            MissingVmResourceError: If the given file path does not exist.
+        Notes:
+            This method interprets the path of the VM resources in the following way:
+
+            * Non-recursively upload all directory files: ``path_to_dir``,
+              ``path_to_dir/``, or ``path_to_dir/*`` (all equivalent)
+            * Non-recursively upload all directory files matching a pattern: ``path_to_dir/*.ext``
+            * Recursively upload all files: ``path_to_dir/**``, ``path_to_dir/**/``, or
+              ``path_to_dir/**/*`` (all equivalent)
+            * Recursively upload all files matching a pattern: ``path_to_dir/**/*.ext``
         """
-        if not vmr_path.exists():
-            raise MissingVmResourceError(vmr_path)
+        if Path(self.path).joinpath(manifest_vm_resource).is_dir():
+            manifest_vm_resource += "/*"
 
-    @staticmethod
-    def _verify_image_exists(image_path):
+        # replace all ** not already followed by **/* with **/*
+        manifest_vm_resource = manifest_vm_resource.replace("**/*", "**")
+        manifest_vm_resource = manifest_vm_resource.replace("**", "**/*")
+        if "*" in manifest_vm_resource:
+            enumerated_resources = [
+                str(p.relative_to(self.path))
+                for p in Path(self.path).glob(manifest_vm_resource)
+                if p.is_file()
+            ]
+        else:
+            enumerated_resources = [manifest_vm_resource]
+        return enumerated_resources
+
+    def _collect_images(self):
         """
-        Verify that the image exists in the model component.
+        Collect all images from the manifest.
 
-        Args:
-            image_path (path): The path to the image to verify.
-
-        Raises:
-            MissingImageError: If the image is not found in the model component.
+        Returns:
+            list: A list of image objects determined from the manifest.
         """
-        if not image_path.exists():
-            # The image does not exist. This is a problem... unless the image is already
-            # in the file store then it may or may not be an issue. Either way, it is
-            # weird and the user should fix it.
-            raise MissingImageError(
-                f"The image {image_path} is not present in the model component."
-            )
-
-    @staticmethod
-    def _get_modification_timestamp(path):
-        return datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+        architecture_image_data = self.manifest.get("images", {})
+        image_relative_paths = chain.from_iterable(
+            info.get("paths", []) for info in architecture_image_data
+        )
+        return [
+            _Image(Path(self.path, image_path), self.image_store)
+            for image_path in image_relative_paths
+        ]
 
     def set_dependency_graph_id(self, new_id):
         """

--- a/src/firewheel/control/model_component.py
+++ b/src/firewheel/control/model_component.py
@@ -375,18 +375,15 @@ class ModelComponent:
 
     def _upload_vm_resource(self, resource):
         """
-        Upload a file to the VmResourceStore.
+        Upload a file to the ``VmResourceStore``.
         It interrupts the path of the VM resources in the following way:
 
-        * Non-recursive all dir's files: `path_to_dir`,
-          `path_to_dir/`, or `path_to_dir/*`
-        * Non-recursive all dir's files matching pattern: `path_to_dir/*.ext`
-        * Recursive all files: `path_to_dir/**`, `path_to_dir/**/`, or `path_to_dir/**/*`
-        * Recursive  all files matching pattern: `path_to_dir/**/*.ext`
-
-        Raises:
-            MissingVmResourceError: if the given file path does not exist,
-                or its modification time cannot be determined.
+        * Non-recursive all dir's files: ``path_to_dir``,
+          ``path_to_dir/``, or ``path_to_dir/*``
+        * Non-recursive all dir's files matching pattern: ``path_to_dir/*.ext``
+        * Recursive all files: ``path_to_dir/**``, ``path_to_dir/**/``, or
+          ``path_to_dir/**/*``
+        * Recursive  all files matching pattern: ``path_to_dir/**/*.ext``
 
         Args:
             resource (str): Path relative to this component's root to the file being
@@ -394,33 +391,29 @@ class ModelComponent:
 
         Returns:
             str: Indication of what happened. This may be one of:
-                `no_date` -- There was no upload date for the given file in the
-                            VmResourceStore. It was uploaded.
-                `new_hash` -- The modified time of the file on disk differs from the
-                            last upload time in the VmResourceStore and the hashes did not match.
-                            File was uploaded.
-                `same_hash` -- The file on disk was modified after the upload time in
-                            the VmResourceStore but the hashes are the same. File was
-                            not uploaded.
-                `False` -- None of the other conditions occurred. For example, the file
-                        on disk was modified before the VmResourceStore upload time
+                ``no_date`` -- There was no upload date for the given file in the
+                    ``VmResourceStore``. It was uploaded.
+                ``new_hash`` -- The modified time of the file on disk differs from the
+                    last upload time in the ``VmResourceStore`` and the hashes did not
+                    match. File was uploaded.
+                ``same_hash`` -- The file on disk was modified after the upload time in
+                    the ``VmResourceStore`` but the hashes are the same. File was not
+                    uploaded.
+                :py:data:`False` -- None of the other conditions occurred. For example,
+                    the file on disk was modified before the ``VmResourceStore`` upload
+                    time.
         """
-        path = os.path.join(self.path, resource)
-        try:
-            modified_time = os.path.getmtime(path)
-            last_modified_date = datetime.fromtimestamp(modified_time, timezone.utc)
-            self.log.debug(
-                "Resource %s in %s has modified time of %s",
-                resource,
-                self.manifest["name"],
-                last_modified_date,
-            )
-        except OSError as exp:
-            raise MissingVmResourceError(path) from exp
+        path = Path(self.path, resource)
+        self._verify_vmr_exists(path)
 
-        upload_date = self.vm_resource_store.get_file_upload_date(
-            os.path.basename(resource)
+        modification_timestamp = self._get_modification_timestamp(path)
+        self.log.debug(
+            "Resource %s in %s has modified time of %s",
+            resource,
+            self.manifest["name"],
+            modification_timestamp,
         )
+        upload_date = self.vm_resource_store.get_file_upload_date(Path(resource).name)
         self.log.debug("VM Resource store file has upload date of %s", upload_date)
 
         if upload_date is None:
@@ -430,7 +423,7 @@ class ModelComponent:
             self.vm_resource_store.add_file(path)
             return "no_date"
 
-        if last_modified_date != upload_date:
+        if modification_timestamp != upload_date:
             self.log.debug("Resource on disk is different from store. Checksuming.")
             resource_hash = hash_file(path)
             store_hash = self.vm_resource_store.get_file_hash(resource)
@@ -454,27 +447,27 @@ class ModelComponent:
         Upload all VM resources from the manifest. It interrupts the path
         of the VM resources in the following way:
 
-        * Non-recursive all dir's files: `path_to_dir`,
-          `path_to_dir/`, or `path_to_dir/*`
-        * Non-recursive all dir's files matching pattern: `path_to_dir/*.ext`
-        * Recursive all files: `path_to_dir/**`, `path_to_dir/**/`, or `path_to_dir/**/*`
-        * Recursive  all files matching pattern: `path_to_dir/**/*.ext`
+        * Non-recursive all dir's files: ``path_to_dir``,
+          ``path_to_dir/``, or ``path_to_dir/*``
+        * Non-recursive all dir's files matching pattern: ``path_to_dir/*.ext``
+        * Recursive all files: ``path_to_dir/**``, ``path_to_dir/**/``, or
+          ``path_to_dir/**/*``
+        * Recursive  all files matching pattern: ``path_to_dir/**/*.ext``
 
         Returns:
-            bool: True if any resource was uploaded, False otherwise.
+            bool: :py:data:`True` if any resource was uploaded, :py:data:`False`
+                otherwise.
 
         Raises:
-            RuntimeError: If the `vm_resources` field in the MANIFEST is not a list.
+            RuntimeError: If the ``vm_resources`` field in the MANIFEST is not a list.
         """
-        if "vm_resources" not in self.manifest:
+        if (vm_resources := self.manifest.get("vm_resources")) is None:
             return False
-
-        if not isinstance(self.manifest["vm_resources"], list):
-            # The vm_resources must be in a list
+        elif not isinstance(vm_resources, list):
+            # The `vm_resources` must be in a list
             raise RuntimeError(
-                'Malformed MANIFEST, the "vm_resources" attribute '
-                f'must be a list. It is currently: "{self.manifest["vm_resources"]}"'
-                f'of type "{type(self.manifest["vm_resources"])}"'
+                'Malformed MANIFEST, the "vm_resources" attribute must be a list. '
+                f"It is currently: `{vm_resources}` of type `{type(vm_resources)}`."
             )
 
         any_uploaded = False
@@ -484,7 +477,7 @@ class ModelComponent:
         # Non-recursive, all dir's files matching pattern path_to_dir/*.ext -> no change
         # Recursive - all files: path_to_dir/**, path_to_dir/**/ -> path_to_dir/**/*
         # Recursive - all files matching pattern: path_to_dir/**/*.ext -> no change
-        for manifest_vm_resource in self.manifest["vm_resources"]:
+        for manifest_vm_resource in vm_resources:
             if Path(self.path).joinpath(manifest_vm_resource).is_dir():
                 manifest_vm_resource += "/*"
 
@@ -515,91 +508,129 @@ class ModelComponent:
         """
         Upload all image files from the manifest.
 
-        Raises:
-            MissingImageError: If the image is not found in the model component.
-
         Returns:
             list: Actions for each specified file. Order is sequential,
             proceeding through images, for each image proceed through each
             specified file before moving to next image. Possible actions are:
 
-            * `no_date` -- There was no upload date for the given file in the
-                           ImageStore. It was uploaded.
-            * `new_hash` -- The modified time of the file on disk differs from the
-                            last upload time in the ImageStore and the hashes did not match.
-                            File was uploaded.
-            * `same_hash` -- The file on disk was modified after the upload time in
-                            the ImageStore but the hashes are the same. File was
-                            not uploaded.
-            * `False` -- None of the other conditions occurred. For example, the file
-                        on disk was modified before the ImageStore upload time
+            * ``no_date`` -- There was no upload date for the given file in the
+                  ``ImageStore``. It was uploaded.
+            * ``new_hash`` -- The modified time of the file on disk differs from the
+                  last upload time in the ``ImageStore`` and the hashes did not match.
+                  File was uploaded.
+            * ``same_hash`` -- The file on disk was modified after the upload time in
+                  the ``ImageStore`` but the hashes are the same. File was
+                  not uploaded.
+            * :py:data:`False` -- None of the other conditions occurred. For example,
+                  the file on disk was modified before the ``ImageStore`` upload time.
+
+            An empty list is returned if no images are identified.
+
         """
-        if "images" not in self.manifest:
-            return False
-        images = self.manifest["images"]
-        ret_val = []
-        for image in images:
-            for end_path in image["paths"]:
-                path = os.path.join(self.path, end_path)
-                try:
-                    modified_time = os.path.getmtime(path)
-                    last_modified_date = datetime.fromtimestamp(
-                        modified_time, timezone.utc
-                    )
-                except OSError as exp:
-                    # The image does not exist. This is a problem...unless the
-                    # image is already in the file store then it may or may not be an
-                    # issue. Either way it is weird and the user should fix it.
-                    raise MissingImageError(
-                        f"The image {path} is not present in the model component."
-                    ) from exp
+        return [
+            self._upload_image(image_path)
+            for image_field in self.manifest.get("images", {})
+            for image_path in image_field.get("paths", [])
+        ]
 
-                # Check the upload date of the image in the FileStore. If the image
-                # does not exist, None will be returned.
-                if not self.image_store.check_path(os.path.basename(path)):
-                    upload_date = None
-                else:
-                    upload_date = self.image_store.get_file_upload_date(
-                        os.path.basename(path)
-                    )
+    def _upload_image(self, image_path):
+        """
+        Upload an image to the ``ImageStore``.
 
-                # If the image does not exist in the FileStore, then add it.
-                # If it does exist, then compare times. If the last modified
-                # time of the disk image is greater than the uploaded time of
-                # the image in the FileStore, then we should check the MD5 sums. If the
-                # MD5 sums differ, than we need to re-upload the image.
-                if upload_date is None:
-                    with Progress(
-                        TextColumn(
-                            f"[yellow]Adding {end_path} to cache. This may take a while."
-                        ),
-                        SpinnerColumn(spinner_name="line"),
-                        TimeElapsedColumn(),
-                    ) as progress:
-                        progress.add_task(description="upload_image")
-                        self.image_store.add_image_file(path)
-                    ret_val.append("no_date")
-                elif last_modified_date != upload_date:
-                    # If date is different then hash it
-                    disk_hash = hash_file(path)
-                    store_hash = self.image_store.get_file_hash(os.path.basename(path))
-                    # If hashes differ upload new image
-                    if disk_hash != store_hash:
-                        with Progress(
-                            TextColumn(
-                                f"[yellow]Updating {end_path} in cache. This may take a while."
-                            ),
-                            SpinnerColumn(spinner_name="line"),
-                            TimeElapsedColumn(),
-                        ) as progress:
-                            progress.add_task(description="upload_image")
-                        self.image_store.add_image_file(path)
-                        ret_val.append("new_hash")
-                    else:
-                        ret_val.append("same_hash")
-                else:
-                    ret_val.append(False)
-        return ret_val
+        Args:
+            image_path (str): A path to an image to be added to the ``ImageStore``.
+
+        Returns:
+            str: An action for the specified image file. Possible actions are:
+
+            * ``no_date`` -- There was no upload date for the given file in the
+                  ``ImageStore``. It was uploaded.
+            * ``new_hash`` -- The modified time of the file on disk differs from the
+                  last upload time in the ``ImageStore`` and the hashes did not match.
+                  File was uploaded.
+            * ``same_hash`` -- The file on disk was modified after the upload time in
+                  the ``ImageStore`` but the hashes are the same. File was
+                  not uploaded.
+            * :py:data:`False` -- None of the other conditions occurred. For example,
+                  the file on disk was modified before the ``ImageStore`` upload time.
+        """
+        path = Path(self.path, image_path)
+        self._verify_image_exists(path)
+
+        modification_timestamp = self._get_modification_timestamp(path)
+        upload_date = self.image_store.get_file_upload_date(path.name)
+
+        # If the image does not exist in the `FileStore`, then add it. If it does exist,
+        # then compare times. If the last modified time of the disk image is greater
+        # than the uploaded time of the image in the `FileStore`, then we should check
+        # the MD5 sums. If the MD5 sums differ, than we need to re-upload the image.
+        if upload_date is None:
+            with Progress(
+                TextColumn(
+                    f"[yellow]Adding {image_path} to cache. This may take a while."
+                ),
+                SpinnerColumn(spinner_name="line"),
+                TimeElapsedColumn(),
+            ) as progress:
+                progress.add_task(description="upload_image")
+                self.image_store.add_image_file(path)
+            return "no_date"
+        elif modification_timestamp != upload_date:
+            # If date is different then hash it
+            disk_hash = hash_file(path)
+            store_hash = self.image_store.get_file_hash(os.path.basename(path))
+            # If hashes differ upload new image
+            if disk_hash != store_hash:
+                with Progress(
+                    TextColumn(
+                        f"[yellow]Updating {image_path} in cache. This may take a while."
+                    ),
+                    SpinnerColumn(spinner_name="line"),
+                    TimeElapsedColumn(),
+                ) as progress:
+                    progress.add_task(description="upload_image")
+                self.image_store.add_image_file(path)
+                return "new_hash"
+            else:
+                return "same_hash"
+        return False
+
+    @staticmethod
+    def _verify_vmr_exists(vmr_path):
+        """
+        Verify that the VM resource exists in the model component.
+
+        Args:
+            vmr_path (path): The path to the VM resource to verify.
+
+        Raises:
+            MissingVmResourceError: If the given file path does not exist.
+        """
+        if not vmr_path.exists():
+            raise MissingVmResourceError(vmr_path)
+
+    @staticmethod
+    def _verify_image_exists(image_path):
+        """
+        Verify that the image exists in the model component.
+
+        Args:
+            image_path (path): The path to the image to verify.
+
+        Raises:
+            MissingImageError: If the image is not found in the model component.
+        """
+        if not image_path.exists():
+            # The image does not exist. This is a problem... unless the image is already
+            # in the file store then it may or may not be an issue. Either way, it is
+            # weird and the user should fix it.
+            raise MissingImageError(
+                f"The image {image_path} is not present in the model component."
+            )
+
+    @staticmethod
+    def _get_modification_timestamp(path):
+        return datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
 
     def set_dependency_graph_id(self, new_id):
         """

--- a/src/firewheel/control/model_component_manager.py
+++ b/src/firewheel/control/model_component_manager.py
@@ -76,12 +76,8 @@ class ModelComponentManager:
 
         Returns:
             list: The list of model components.
-
-        Raises:
-            InvalidStateError: If the dependency graph does not exist.
         """
-        if not self.dg:
-            raise InvalidStateError("Dependency graph not constructed yet.")
+        self.validate_dependency_graph()
         return self.dg.get_ordered_entity_list()
 
     def get_default_component_for_attribute(self, attribute, install_mcs=None):
@@ -651,19 +647,16 @@ class ModelComponentManager:
         Builds the experiment graph by processing all the model components.
 
         Args:
-            dry_run (bool): Indicates whether the model components should be run (:py:data:`False`)
-                or simply imported (i.e. checked for syntax errors). Defaults to :py:data:`False`.
+            dry_run (bool): Indicates whether the model components should be
+                run (:py:data:`False`) or simply imported (i.e., checked for
+                syntax errors). Defaults to :py:data:`False`.
 
         Returns:
             list: A list of errors that were reported when trying to execute.
-
-
-        Raises:
-            InvalidStateError: If the dependency graph does not exist.
         """
+        self.validate_dependency_graph()
+        # Set initial values before processing MCs
         errors_list = []
-        if self.dg is None:
-            raise InvalidStateError("No dependency graph generated yet.")
         experiment_graph = None
 
         for mc in self.get_ordered_model_component_list():
@@ -682,3 +675,13 @@ class ModelComponentManager:
             )
 
         return errors_list
+
+    def validate_dependency_graph(self):
+        """
+        Validate the existence of the dependency graph.
+
+        Raises:
+            InvalidStateError: If the dependency graph does not exist.
+        """
+        if self.dg is None:
+            raise InvalidStateError("No dependency graph generated yet.")

--- a/src/firewheel/tests/unit/control/test_model_component.py
+++ b/src/firewheel/tests/unit/control/test_model_component.py
@@ -246,29 +246,20 @@ class ModelComponentTestCase(unittest.TestCase):
         # Make sure name is set correctly.
         self.assertEqual(m.name, self.manifest["name"])
 
-    def test_repository_prop(self):
-        m = ModelComponent(path=self.c11)
-        self.assertNotEqual(m, None)
+    def test_repository_db(self):
+        # Ensure that the attribute defaults to the appropriate object if not specified
+        mc = ModelComponent(path=self.c11)
+        self.assertIsInstance(mc.repository_db, RepositoryDb)
 
-        self.assertIsInstance(m.repository_db, RepositoryDb)
-        m.repository_db = None
-        self.assertIsInstance(m.repository_db, RepositoryDb)
+    def test_vm_resource_store(self):
+        # Ensure that the attribute defaults to the appropriate object if not specified
+        mc = ModelComponent(path=self.c11)
+        self.assertIsInstance(mc.vm_resource_store, VmResourceStore)
 
-    def test_vm_resource_store_prop(self):
-        m = ModelComponent(path=self.c11)
-        self.assertNotEqual(m, None)
-
-        self.assertIsInstance(m.vm_resource_store, VmResourceStore)
-        m.vm_resource_store = None
-        self.assertIsInstance(m.vm_resource_store, VmResourceStore)
-
-    def test_image_store_prop(self):
-        m = ModelComponent(path=self.c11)
-        self.assertNotEqual(m, None)
-
-        self.assertIsInstance(m.image_store, ImageStore)
-        m.image_store = None
-        self.assertIsInstance(m.image_store, ImageStore)
+    def test_image_store(self):
+        # Ensure that the attribute defaults to the appropriate object if not specified
+        mc = ModelComponent(path=self.c11)
+        self.assertIsInstance(mc.image_store, ImageStore)
 
     def test_fail_resolve(self):
         with self.assertRaises(ValueError):
@@ -400,15 +391,3 @@ class ModelComponentTestCase(unittest.TestCase):
             mc = ModelComponent(
                 path=self.c11, arguments={}, repository_db=self.repository_db
             )
-
-    # pylint: disable=unused-variable
-    def test_exercise_properties(self):
-        mc = ModelComponent(
-            name=self.manifest["name"], repository_db=self.repository_db
-        )
-        self.assertTrue(isinstance(mc, ModelComponent))
-
-        # Failed when AttributeErrors were unhandled in properties.
-        img_store = mc.image_store  # noqa: F841
-        vm_resource_store = mc.vm_resource_store  # noqa: F841
-        self.assertEqual(mc.repository_db, self.repository_db)

--- a/src/firewheel/tests/unit/control/test_model_component_image_upload.py
+++ b/src/firewheel/tests/unit/control/test_model_component_image_upload.py
@@ -98,7 +98,7 @@ echo 'Hello, World!'
         self.assertEqual(image_list, [])
 
         res = mcp._upload_images()
-        self.assertEqual(res, ["no_date"])
+        self.assertEqual(res, {self.image_file_name: "no_date"})
 
         image_list = self.image_store.list_contents()
         image_list = [image[self.fn_key] for image in image_list]
@@ -115,8 +115,8 @@ echo 'Hello, World!'
         image_list = [image[self.fn_key] for image in image_list]
         self.assertEqual(image_list, [])
 
-        res = mcp._upload_images()
-        self.assertEqual(res, ["no_date"])
+        result = mcp._upload_images()
+        self.assertEqual(result, {self.image_file_name: "no_date"})
 
         first_upload_time = self.image_store.get_file_upload_date(self.image_file_name)
         image_list = self.image_store.list_contents()
@@ -125,8 +125,8 @@ echo 'Hello, World!'
 
         # Make sure our upload time would change if we re-uploaded
         time.sleep(2)
-        res = mcp._upload_images()
-        self.assertEqual(res, [False])
+        result = mcp._upload_images()
+        self.assertEqual(result, {self.image_file_name: False})
 
         second_upload_time = self.image_store.get_file_upload_date(self.image_file_name)
         image_list = self.image_store.list_contents()
@@ -160,14 +160,14 @@ echo 'Hello, World!'
         mcp.manifest["images"][0] = {"paths": [image_rel_path]}
 
         result = mcp._upload_images()
-        self.assertEqual(result, ["no_date"])
+        self.assertEqual(result, {image_rel_path: "no_date"})
 
         image_list = self.image_store.list_contents()
         image_list = [image[self.fn_key] for image in image_list]
         self.assertEqual(image_list, [image_name])
 
         result = mcp._upload_images()
-        self.assertEqual(result, [False])
+        self.assertEqual(result, {image_rel_path: False})
 
     def test_upload_new_time_same_hash(self):
         mcp = ModelComponent(
@@ -180,7 +180,7 @@ echo 'Hello, World!'
         pre_hash = hash_file(self.image1_path)
 
         result = mcp._upload_images()
-        self.assertEqual(result, ["no_date"])
+        self.assertEqual(result, {self.image_file_name: "no_date"})
 
         upload_time = self.image_store.get_file_upload_date(self.image_file_name)
         upload_hash = self.image_store.get_file_hash(self.image_file_name)
@@ -202,7 +202,7 @@ echo 'Hello, World!'
         self.assertTrue(post_time > pre_time)
 
         result = mcp._upload_images()
-        self.assertEqual(result, ["same_hash"])
+        self.assertEqual(result, {self.image_file_name: "same_hash"})
 
     def test_upload_new_time_new_hash(self):
         mcp = ModelComponent(
@@ -215,7 +215,7 @@ echo 'Hello, World!'
         pre_hash = hash_file(self.image1_path)
 
         result = mcp._upload_images()
-        self.assertEqual(result, ["no_date"])
+        self.assertEqual(result, {self.image_file_name: "no_date"})
 
         upload_time = self.image_store.get_file_upload_date(self.image_file_name)
         upload_hash = self.image_store.get_file_hash(self.image_file_name)
@@ -237,7 +237,7 @@ echo 'Hello, World!'
         self.assertTrue(post_time > pre_time)
 
         result = mcp._upload_images()
-        self.assertEqual(result, ["new_hash"])
+        self.assertEqual(result, {self.image_file_name: "new_hash"})
 
     def test_upload_old_time_new_hash(self):
         # What is this test case accomplishing?
@@ -261,7 +261,7 @@ echo 'Hello, World!'
         time.sleep(2)
 
         result = mcp._upload_images()
-        self.assertEqual(result, ["no_date"])
+        self.assertEqual(result, {self.image_file_name: "no_date"})
 
         upload_time = self.image_store.get_file_upload_date(self.image_file_name)
         self.assertEqual(upload_time, second_time)
@@ -273,7 +273,7 @@ echo 'Hello, World!'
         self.assertNotEqual(second_hash, post_hash)
 
         result = mcp._upload_images()
-        self.assertEqual(result, [False])
+        self.assertEqual(result, {self.image_file_name: False})
 
     def test_upload_revert_same_file(self):
         mcp = ModelComponent(
@@ -286,7 +286,7 @@ echo 'Hello, World!'
         pre_hash = hash_file(self.image1_path)
 
         result = mcp._upload_images()
-        self.assertEqual(result, ["no_date"])
+        self.assertEqual(result, {self.image_file_name: "no_date"})
 
         upload_time = self.image_store.get_file_upload_date(self.image_file_name)
         upload_hash = self.image_store.get_file_hash(self.image_file_name)
@@ -314,7 +314,7 @@ echo 'Hello, World!'
         self.assertTrue(post_time > pre_time)
 
         result = mcp._upload_images()
-        self.assertEqual(result, ["new_hash"])
+        self.assertEqual(result, {self.image_file_name: "new_hash"})
 
         upload_time = self.image_store.get_file_upload_date(self.image_file_name)
         upload_hash = self.image_store.get_file_hash(self.image_file_name)
@@ -347,7 +347,7 @@ echo 'Hello, World!'
 
         # This should be uploaded because even though the time is "older" the contents
         # are newer.
-        self.assertEqual(result, ["new_hash"])
+        self.assertEqual(result, {self.image_file_name: "new_hash"})
 
     def test_upload_image_one_not_another_from_manifest(self):
         mcp = ModelComponent(

--- a/src/firewheel/tests/unit/control/test_model_component_image_upload.py
+++ b/src/firewheel/tests/unit/control/test_model_component_image_upload.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 import yaml
 
@@ -64,79 +65,102 @@ echo 'Hello, World!'
         # remove the temp directories
         shutil.rmtree(self.tmpdir)
 
+    def _get_image_store_files(self):
+        return [image[self.fn_key] for image in self.image_store.list_contents()]
+
     def test_upload_image_no_manifest_property(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             image_store=self.image_store,
         )
-        del mcp.manifest["images"]
+        del mc.manifest["images"]
 
-        res = mcp._upload_images()
-        self.assertFalse(res)
+        mc.upload_files()
+        self.assertEqual(self._get_image_store_files(), [])
 
     def test_missing_image(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             image_store=self.image_store,
         )
 
-        mcp.manifest["images"][0] = {"paths": ["invalid"]}
+        mc.manifest["images"][0] = {"paths": ["invalid"]}
         with self.assertRaises(MissingImageError):
-            mcp._upload_images()
+            mc.upload_files()
 
     def test_upload_image(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             image_store=self.image_store,
         )
 
-        image_list = self.image_store.list_contents()
-        image_list = [image[self.fn_key] for image in image_list]
-        self.assertEqual(image_list, [])
+        self.assertEqual(self._get_image_store_files(), [])
 
-        res = mcp._upload_images()
-        self.assertEqual(res, {self.image_file_name: "no_date"})
+        mc.upload_files()
 
-        image_list = self.image_store.list_contents()
-        image_list = [image[self.fn_key] for image in image_list]
-        self.assertEqual(image_list, [self.image_file_name])
+        self.assertEqual(self._get_image_store_files(), [self.image_file_name])
 
-    def test_double_upload_image(self):
-        mcp = ModelComponent(
+    def test_existing_images_not_reuploaded_single(self):
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             image_store=self.image_store,
         )
+        with patch.object(
+            mc.image_store, "add_image_file", wraps=mc.image_store.add_image_file
+        ) as mock_image_upload_method:
+            self.assertEqual(self._get_image_store_files(), [])
 
-        image_list = self.image_store.list_contents()
-        image_list = [image[self.fn_key] for image in image_list]
-        self.assertEqual(image_list, [])
+            mc.upload_files()
+            mock_image_upload_method.assert_called_once()
+            self.assertEqual(self._get_image_store_files(), [self.image_file_name])
 
-        result = mcp._upload_images()
-        self.assertEqual(result, {self.image_file_name: "no_date"})
+            mock_image_upload_method.reset_mock()
+            mc.upload_files()
+            # Ensure no uploads occurred after the reset (image exists)
+            mock_image_upload_method.assert_not_called()
+            self.assertEqual(self._get_image_store_files(), [self.image_file_name])
 
-        first_upload_time = self.image_store.get_file_upload_date(self.image_file_name)
-        image_list = self.image_store.list_contents()
-        image_list = [image[self.fn_key] for image in image_list]
-        self.assertEqual(image_list, [self.image_file_name])
+    def test_existing_images_not_reuploaded_double(self):
+        mc = ModelComponent(
+            path=self.mc_dir,
+            repository_db=self.repository_db,
+            image_store=self.image_store,
+        )
+        with patch.object(
+            mc.image_store, "add_image_file", wraps=mc.image_store.add_image_file
+        ) as mock_image_upload_method:
+            self.assertEqual(self._get_image_store_files(), [])
 
-        # Make sure our upload time would change if we re-uploaded
-        time.sleep(2)
-        result = mcp._upload_images()
-        self.assertEqual(result, {self.image_file_name: False})
+            mc.upload_files()
+            mock_image_upload_method.assert_called_once()
+            self.assertEqual(self._get_image_store_files(), [self.image_file_name])
 
-        second_upload_time = self.image_store.get_file_upload_date(self.image_file_name)
-        image_list = self.image_store.list_contents()
-        image_list = [image[self.fn_key] for image in image_list]
-        self.assertEqual(image_list, [self.image_file_name])
+            second_image_name = "second_image"
+            second_image_contents = "SECOND IMAGE!"
+            second_image_path = os.path.join(self.mc_dir, second_image_name)
+            time.sleep(1)
+            with open(second_image_path, "w", encoding="utf8") as fname:
+                fname.write(second_image_contents)
 
-        self.assertEqual(first_upload_time, second_upload_time)
+            old_image_list = mc.manifest["images"]
+            mc.manifest["images"] = [{"paths": [second_image_name]}]
+            mc.manifest["images"].extend(old_image_list)
+
+            mock_image_upload_method.reset_mock()
+            mc.upload_files()
+            # Ensure that only one upload occurs after reset (for the second image)
+            mock_image_upload_method.assert_called_once()
+            self.assertEqual(
+                sorted(self._get_image_store_files()),
+                sorted([self.image_file_name, second_image_name]),
+            )
 
     def test_upload_subdir_image(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             image_store=self.image_store,
@@ -153,95 +177,86 @@ echo 'Hello, World!'
         with open(image_path, "w", encoding="utf8") as fname:
             fname.write(image_contents)
 
-        image_list = self.image_store.list_contents()
-        image_list = [image[self.fn_key] for image in image_list]
-        self.assertEqual(image_list, [])
+        self.assertEqual(self._get_image_store_files(), [])
 
-        mcp.manifest["images"][0] = {"paths": [image_rel_path]}
+        mc.manifest["images"][0] = {"paths": [image_rel_path]}
+        mc.upload_files()
 
-        result = mcp._upload_images()
-        self.assertEqual(result, {image_rel_path: "no_date"})
-
-        image_list = self.image_store.list_contents()
-        image_list = [image[self.fn_key] for image in image_list]
-        self.assertEqual(image_list, [image_name])
-
-        result = mcp._upload_images()
-        self.assertEqual(result, {image_rel_path: False})
+        self.assertEqual(self._get_image_store_files(), [image_name])
 
     def test_upload_new_time_same_hash(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             image_store=self.image_store,
         )
 
-        pre_time = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
+        pre_timestamp = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
         pre_hash = hash_file(self.image1_path)
 
-        result = mcp._upload_images()
-        self.assertEqual(result, {self.image_file_name: "no_date"})
+        mc.upload_files()
 
-        upload_time = self.image_store.get_file_upload_date(self.image_file_name)
+        upload_timestamp = self.image_store.get_file_upload_date(self.image_file_name)
         upload_hash = self.image_store.get_file_hash(self.image_file_name)
-        self.assertEqual(upload_time, pre_time)
+        self.assertEqual(upload_timestamp, pre_timestamp)
         self.assertEqual(upload_hash, pre_hash)
 
-        # Sleep so we are sure we get a new time.
-        time.sleep(2)
+        # Rewrite the file after a delay to ensure a new timestamp
+        time.sleep(1)
         with open(self.image1_path, "w", encoding="utf8") as fname:
             fname.write(self.image1)
 
-        post_time = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
+        post_timestamp = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
         post_hash = hash_file(self.image1_path)
-
-        self.assertNotEqual(pre_time, post_time)
-        self.assertTrue(upload_time < post_time)
+        self.assertTrue(pre_timestamp < post_timestamp)
+        self.assertTrue(upload_timestamp < post_timestamp)
         self.assertEqual(pre_hash, post_hash)
 
-        self.assertTrue(post_time > pre_time)
+        mc.upload_files()
 
-        result = mcp._upload_images()
-        self.assertEqual(result, {self.image_file_name: "same_hash"})
+        new_upload_timestamp = self.image_store.get_file_upload_date(self.image_file_name)
+        new_upload_hash = self.image_store.get_file_hash(self.image_file_name)
+        self.assertEqual(new_upload_timestamp, upload_timestamp)
+        self.assertEqual(new_upload_hash, upload_hash)
 
     def test_upload_new_time_new_hash(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             image_store=self.image_store,
         )
 
-        pre_time = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
+        pre_timestamp = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
         pre_hash = hash_file(self.image1_path)
 
-        result = mcp._upload_images()
-        self.assertEqual(result, {self.image_file_name: "no_date"})
+        mc.upload_files()
 
-        upload_time = self.image_store.get_file_upload_date(self.image_file_name)
+        upload_timestamp = self.image_store.get_file_upload_date(self.image_file_name)
         upload_hash = self.image_store.get_file_hash(self.image_file_name)
-        self.assertEqual(upload_time, pre_time)
+        self.assertEqual(upload_timestamp, pre_timestamp)
         self.assertEqual(upload_hash, pre_hash)
 
-        # Sleep so we are sure we get a new time.
-        time.sleep(2)
+        # Rewrite the file after a delay to ensure a new timestamp and new contents
+        time.sleep(1)
         with open(self.image1_path, "w", encoding="utf8") as fname:
             fname.write("different contents")
 
-        post_time = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
+        post_timestamp = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
         post_hash = hash_file(self.image1_path)
-
-        self.assertNotEqual(pre_time, post_time)
-        self.assertTrue(upload_time < post_time)
+        self.assertTrue(pre_timestamp < post_timestamp)
+        self.assertTrue(upload_timestamp < post_timestamp)
         self.assertNotEqual(pre_hash, post_hash)
 
-        self.assertTrue(post_time > pre_time)
+        mc.upload_files()
 
-        result = mcp._upload_images()
-        self.assertEqual(result, {self.image_file_name: "new_hash"})
+        new_upload_timestamp = self.image_store.get_file_upload_date(self.image_file_name)
+        new_upload_hash = self.image_store.get_file_hash(self.image_file_name)
+        self.assertNotEqual(new_upload_timestamp, upload_timestamp)
+        self.assertNotEqual(new_upload_hash, upload_hash)
 
     def test_upload_old_time_new_hash(self):
         # What is this test case accomplishing?
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             image_store=self.image_store,
@@ -250,7 +265,7 @@ echo 'Hello, World!'
         subdir = "subdir"
         second_image_path = os.path.join(self.mc_dir, subdir, self.image_file_name)
         os.makedirs(os.path.join(self.mc_dir, subdir))
-        time.sleep(2)
+        time.sleep(1)
         with open(second_image_path, "w", encoding="utf8") as fname:
             fname.write("different contents")
 
@@ -258,10 +273,10 @@ echo 'Hello, World!'
         second_hash = hash_file(second_image_path)
 
         # Sleep so we are sure we get a new time.
-        time.sleep(2)
+        time.sleep(1)
 
-        result = mcp._upload_images()
-        self.assertEqual(result, {self.image_file_name: "no_date"})
+        mc.upload_files()
+        # self.assertEqual(result, {self.image_file_name: "no_date"})
 
         upload_time = self.image_store.get_file_upload_date(self.image_file_name)
         self.assertEqual(upload_time, second_time)
@@ -272,29 +287,29 @@ echo 'Hello, World!'
         self.assertEqual(store_hash, post_hash)
         self.assertNotEqual(second_hash, post_hash)
 
-        result = mcp._upload_images()
-        self.assertEqual(result, {self.image_file_name: False})
+        mc.upload_files()
+        # self.assertEqual(result, {self.image_file_name: False})
+        assert False
 
     def test_upload_revert_same_file(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             image_store=self.image_store,
         )
 
-        pre_time = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
+        pre_timestamp = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
         pre_hash = hash_file(self.image1_path)
 
-        result = mcp._upload_images()
-        self.assertEqual(result, {self.image_file_name: "no_date"})
+        mc.upload_files()
 
-        upload_time = self.image_store.get_file_upload_date(self.image_file_name)
+        upload_timestamp = self.image_store.get_file_upload_date(self.image_file_name)
         upload_hash = self.image_store.get_file_hash(self.image_file_name)
-        self.assertEqual(upload_time, pre_time)
+        self.assertEqual(upload_timestamp, pre_timestamp)
         self.assertEqual(upload_hash, pre_hash)
 
         # Sleep so we are sure we get a new time.
-        time.sleep(2)
+        time.sleep(1)
 
         # Move the file elsewhere
         tmp_path = tempfile.mkstemp()
@@ -304,98 +319,38 @@ echo 'Hello, World!'
         with open(self.image1_path, "w", encoding="utf8") as fname:
             fname.write("different contents")
 
-        post_time = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
+        post_timestamp = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
         post_hash = hash_file(self.image1_path)
-
-        self.assertNotEqual(pre_time, post_time)
-        self.assertTrue(upload_time < post_time)
+        self.assertTrue(pre_timestamp < post_timestamp)
+        self.assertTrue(upload_timestamp < post_timestamp)
         self.assertNotEqual(pre_hash, post_hash)
 
-        self.assertTrue(post_time > pre_time)
+        mc.upload_files()
 
-        result = mcp._upload_images()
-        self.assertEqual(result, {self.image_file_name: "new_hash"})
-
-        upload_time = self.image_store.get_file_upload_date(self.image_file_name)
-        upload_hash = self.image_store.get_file_hash(self.image_file_name)
+        new_upload_timestamp = self.image_store.get_file_upload_date(self.image_file_name)
+        new_upload_hash = self.image_store.get_file_hash(self.image_file_name)
+        self.assertEqual(new_upload_timestamp, post_timestamp)
+        self.assertEqual(new_upload_hash, post_hash)
 
         # Sleep so we are sure we get a new time.
-        time.sleep(2)
+        time.sleep(1)
 
         # Revert to previous file
-        rev_time = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
+        pre_rev_timestamp = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
         rev_hash = hash_file(self.image1_path)
         shutil.move(tmp_path[1], self.image1_path)
+        post_rev_timestamp = datetime.utcfromtimestamp(os.path.getmtime(self.image1_path))
+        post_rev_hash = hash_file(self.image1_path)
+        # The file was moved so the original and post-reversion times should be the same
+        self.assertEqual(pre_timestamp, post_rev_timestamp)
+        # ...but the file is different than the file being reverted
+        self.assertNotEqual(pre_rev_timestamp, post_rev_timestamp)
+        self.assertNotEqual(pre_rev_hash, post_rev_hash)
+        # ...and the reverted timestamp will be older than the one in the file store
+        self.assertTrue(post_rev_timestamp < new_upload_timestamp)
 
-        post_time = datetime.fromtimestamp(os.path.getmtime(self.image1_path), timezone.utc)
-        post_hash = hash_file(self.image1_path)
-
-        # The file was moved so the pre/post time should be the same
-        self.assertEqual(pre_time, post_time)
-
-        # But the file is different than the file being reverted
-        self.assertNotEqual(rev_time, post_time)
-        self.assertNotEqual(rev_hash, post_hash)
-
-        # Because the file was revered the time will be older than the upload_time
-        self.assertTrue(upload_time > post_time)
-
-        # And the file will be older than the reverted file
-        self.assertTrue(rev_time > post_time)
-
-        result = mcp._upload_images()
+        mc.upload_files()
 
         # This should be uploaded because even though the time is "older" the contents
         # are newer.
-        self.assertEqual(result, {self.image_file_name: "new_hash"})
-
-    def test_upload_image_one_not_another_from_manifest(self):
-        mcp = ModelComponent(
-            path=self.mc_dir,
-            repository_db=self.repository_db,
-            image_store=self.image_store,
-        )
-
-        image_list = self.image_store.list_contents()
-        image_list = [image[self.fn_key] for image in image_list]
-        self.assertEqual(image_list, [])
-
-        result = mcp._upload_images()
-        self.assertTrue(result)
-
-        image_list = self.image_store.list_contents()
-        image_list = [image[self.fn_key] for image in image_list]
-        self.assertEqual(image_list, [self.image_file_name])
-        first_upload_date = self.image_store.get_file_upload_date(self.image_file_name)
-
-        second_image_name = "second_image"
-        second_image_contents = "SECOND IMAGE!"
-        second_image_path = os.path.join(self.mc_dir, second_image_name)
-        time.sleep(1)
-        with open(second_image_path, "w", encoding="utf8") as fname:
-            fname.write(second_image_contents)
-
-        old_image_list = mcp.manifest["images"]
-        mcp.manifest["images"] = [{"paths": [second_image_name]}]
-        mcp.manifest["images"].extend(old_image_list)
-
-        # Make sure we get different upload dates.
-        time.sleep(2)
-
-        result = mcp._upload_images()
-        self.assertTrue(result)
-
-        image_list = self.image_store.list_contents()
-        image_list = [image[self.fn_key] for image in image_list]
-        image_list.sort()
-        expected_list = [second_image_name, self.image_file_name]
-        expected_list.sort()
-
-        self.assertEqual(image_list, expected_list)
-
-        second_upload_date = self.image_store.get_file_upload_date(self.image_file_name)
-        second_image_upload_date = self.image_store.get_file_upload_date(
-            second_image_name
-        )
-        self.assertEqual(first_upload_date, second_upload_date)
-        self.assertNotEqual(second_upload_date, second_image_upload_date)
+        assert False

--- a/src/firewheel/tests/unit/control/test_model_component_vm_resource_upload.py
+++ b/src/firewheel/tests/unit/control/test_model_component_vm_resource_upload.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 import yaml
 
@@ -68,94 +69,143 @@ echo 'Hello, World!'
         # remove the temp directories
         shutil.rmtree(self.tmpdir)
 
+    def _get_vm_resource_store_files(self):
+        return [
+            resource[self.fn_key] for resource in self.vm_resource_store.list_contents()
+        ]
+
     def test_upload_resource_no_manifest_property(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
-        del mcp.manifest["vm_resources"]
+        del mc.manifest["vm_resources"]
 
-        res = mcp._upload_vm_resources()
-        self.assertFalse(res)
+        mc.upload_files()
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
     def test_missing_resource(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
 
-        with self.assertRaises(MissingVmResourceError):
-            mcp._upload_vm_resource("invalid")
-
-    def test_missing_resource_str(self):
-        mcp = ModelComponent(
-            path=self.mc_dir,
-            repository_db=self.repository_db,
-            vm_resource_store=self.vm_resource_store,
-        )
-
-        try:
-            mcp._upload_vm_resource("invalid")
-        except MissingVmResourceError as exp:
-            self.assertTrue("is not present" in str(exp))
+        mc.manifest["vm_resources"] = ["invalid"]
+        with self.assertRaisesRegex(MissingVmResourceError, ".*is not present.*"):
+            mc.upload_files()
 
     def test_upload_resource(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
-        res = mcp._upload_vm_resource(self.resource_file_name)
-        self.assertEqual(res, "no_date")
+        mc.upload_files()
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [self.resource_file_name])
+        self.assertEqual(self._get_vm_resource_store_files(), [self.resource_file_name])
 
-    def test_double_upload_resource(self):
-        mcp = ModelComponent(
+    def test_upload_vmr_invalid_string(self):
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
-        res = mcp._upload_vm_resource(self.resource_file_name)
-        self.assertEqual(res, "no_date")
+        mc.manifest["vm_resources"] = "string"
+        with self.assertRaisesRegex(RuntimeError, ".*must be a list.*"):
+            mc.upload_files()
 
-        first_upload_time = self.vm_resource_store.get_file_upload_date(
-            self.resource_file_name
+    def test_upload_vmr_invalid_int(self):
+        mc = ModelComponent(
+            path=self.mc_dir,
+            repository_db=self.repository_db,
+            vm_resource_store=self.vm_resource_store,
         )
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [self.resource_file_name])
 
-        # Make sure our upload time would change if we re-uploaded
-        time.sleep(2)
-        res = mcp._upload_vm_resource(self.resource_file_name)
-        self.assertEqual(res, False)
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
-        second_upload_time = self.vm_resource_store.get_file_upload_date(
-            self.resource_file_name
+        mc.manifest["vm_resources"] = 52
+        with self.assertRaisesRegex(RuntimeError, ".*must be a list.*"):
+            mc.upload_files()
+
+    def test_upload_vmr_dict(self):
+        mc = ModelComponent(
+            path=self.mc_dir,
+            repository_db=self.repository_db,
+            vm_resource_store=self.vm_resource_store,
         )
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [self.resource_file_name])
 
-        self.assertEqual(first_upload_time, second_upload_time)
+        self.assertEqual(self._get_vm_resource_store_files(), [])
+
+        mc.manifest["vm_resources"] = {}
+        with self.assertRaisesRegex(RuntimeError, ".*must be a list.*"):
+            mc.upload_files()
+
+    def test_existing_vmr_not_reuploaded_single(self):
+        mc = ModelComponent(
+            path=self.mc_dir,
+            repository_db=self.repository_db,
+            vm_resource_store=self.vm_resource_store,
+        )
+        with patch.object(
+            mc.vm_resource_store, "add_file", wraps=mc.vm_resource_store.add_file
+        ) as mock_vmr_upload_method:
+            self.assertEqual(self._get_vm_resource_store_files(), [])
+
+            mc.upload_files()
+            mock_vmr_upload_method.assert_called_once()
+            self.assertEqual(self._get_vm_resource_store_files(), [self.resource_file_name])
+
+            mock_vmr_upload_method.reset_mock()
+            mc.upload_files()
+            # Ensure that no uploads occurred after the reset (VMR exists)
+            mock_vmr_upload_method.assert_not_called()
+            self.assertEqual(self._get_vm_resource_store_files(), [self.resource_file_name])
+
+    def test_existing_vmr_not_reuploaded_double(self):
+        mc = ModelComponent(
+            path=self.mc_dir,
+            repository_db=self.repository_db,
+            vm_resource_store=self.vm_resource_store,
+        )
+        with patch.object(
+            mc.vm_resource_store, "add_file", wraps=mc.vm_resource_store.add_file
+        ) as mock_vmr_upload_method:
+            self.assertEqual(self._get_vm_resource_store_files(), [])
+
+            mc.upload_files()
+            mock_vmr_upload_method.assert_called_once()
+            self.assertEqual(self._get_vm_resource_store_files(), [self.resource_file_name])
+
+            second_resource_name = "resource2.sh"
+            second_resource_contents = "#!/bin/bash"
+            second_resource_path = os.path.join(self.mc_dir, second_resource_name)
+            time.sleep(1)
+            with open(second_resource_path, "w", encoding="utf8") as fname:
+                fname.write(second_resource_contents)
+
+            old_resource_list = mc.manifest["vm_resources"]
+            mc.manifest["vm_resources"] = [second_resource_name]
+            mc.manifest["vm_resources"].extend(old_resource_list)
+
+            mock_vmr_upload_method.reset_mock()
+            mc.upload_files()
+            # Ensure that only one upload occurs after the reset (for the second VMR)
+            mock_vmr_upload_method.assert_called_once()
+            self.assertEqual(
+                sorted(self._get_vm_resource_store_files()),
+                sorted([self.resource_file_name, second_resource_name]),
+            )
 
     def test_upload_subdir_resource(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
@@ -172,29 +222,19 @@ echo 'Hello, World!'
         with open(resource_path, "w", encoding="utf8") as fname:
             fname.write(resource_contents)
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
-        result = mcp._upload_vm_resource(resource_rel_path)
-        self.assertEqual(result, "no_date")
+        mc.manifest["vm_resources"] = [f"{resource_subdir}/{resource_name}"]
+        mc.upload_files()
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [resource_name])
-        result = mcp._upload_vm_resource(resource_rel_path)
-        self.assertEqual(result, False)
+        self.assertEqual(self._get_vm_resource_store_files(), [resource_name])
 
     def test_upload_from_manifest_star(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
 
         # Add a sub dir and new VM Resources
         resource_name = "subdir_vm_resource.sh"
@@ -207,24 +247,19 @@ echo 'Hello, World!'
         with open(resource_path, "w", encoding="utf8") as fname:
             fname.write(resource_contents)
 
-        mcp.manifest["vm_resources"] = [f"{resource_subdir}/*"]
-        res = mcp._upload_vm_resources()
-        self.assertTrue(res)
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [resource_name])
+        mc.manifest["vm_resources"] = [f"{resource_subdir}/*"]
+        mc.upload_files()
+
+        self.assertEqual(self._get_vm_resource_store_files(), [resource_name])
 
     def test_upload_from_manifest_doublestar(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
 
         # Add a sub dir and new VM Resources
         resource_name = "subdir_vm_resource.sh"
@@ -237,24 +272,19 @@ echo 'Hello, World!'
         with open(resource_path, "w", encoding="utf8") as fname:
             fname.write(resource_contents)
 
-        mcp.manifest["vm_resources"] = [f"{resource_subdir}/**"]
-        res = mcp._upload_vm_resources()
-        self.assertTrue(res)
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [resource_name])
+        mc.manifest["vm_resources"] = [f"{resource_subdir}/**"]
+        mc.upload_files()
+
+        self.assertEqual(self._get_vm_resource_store_files(), [resource_name])
 
     def test_upload_from_manifest_double_star_star(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
 
         # Add a sub dir and new VM Resources
         resource_name = "subdir_vm_resource.sh"
@@ -267,24 +297,19 @@ echo 'Hello, World!'
         with open(resource_path, "w", encoding="utf8") as fname:
             fname.write(resource_contents)
 
-        mcp.manifest["vm_resources"] = [f"{resource_subdir}/**/*"]
-        res = mcp._upload_vm_resources()
-        self.assertTrue(res)
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [resource_name])
+        mc.manifest["vm_resources"] = [f"{resource_subdir}/**/*"]
+        mc.upload_files()
+
+        self.assertEqual(self._get_vm_resource_store_files(), [resource_name])
 
     def test_upload_from_manifest_double_star_limit(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
 
         # Add a sub dir and new VM Resources
         resource_name = "subdir_vm_resource.sh"
@@ -297,24 +322,19 @@ echo 'Hello, World!'
         with open(resource_path, "w", encoding="utf8") as fname:
             fname.write(resource_contents)
 
-        mcp.manifest["vm_resources"] = [f"{resource_subdir}/**/*.py"]
-        res = mcp._upload_vm_resources()
-        self.assertFalse(res)
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
+        mc.manifest["vm_resources"] = [f"{resource_subdir}/**/*.py"]
+        mc.upload_files()
+
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
     def test_upload_from_manifest_double_star_recurse(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
 
         # Add a sub dir and new VM Resources
         resource_name = "subdir_vm_resource.sh"
@@ -327,24 +347,19 @@ echo 'Hello, World!'
         with open(resource_path, "w", encoding="utf8") as fname:
             fname.write(resource_contents)
 
-        mcp.manifest["vm_resources"] = [f"{resource_subdir}/**"]
-        res = mcp._upload_vm_resources()
-        self.assertTrue(res)
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [resource_name])
+        mc.manifest["vm_resources"] = [f"{resource_subdir}/**"]
+        mc.upload_files()
+
+        self.assertEqual(self._get_vm_resource_store_files(), [resource_name])
 
     def test_upload_from_manifest_is_dir(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
 
         # Add a sub dir and new VM Resources
         resource_name = "subdir_vm_resource.sh"
@@ -357,53 +372,54 @@ echo 'Hello, World!'
         with open(resource_path, "w", encoding="utf8") as fname:
             fname.write(resource_contents)
 
-        mcp.manifest["vm_resources"] = [f"{resource_subdir}"]
-        res = mcp._upload_vm_resources()
-        self.assertTrue(res)
+        self.assertEqual(self._get_vm_resource_store_files(), [])
 
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [resource_name])
+        mc.manifest["vm_resources"] = [f"{resource_subdir}"]
+        mc.upload_files()
+
+        self.assertEqual(self._get_vm_resource_store_files(), [resource_name])
 
     def test_upload_new_time_same_hash(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
         )
 
-        pre_time = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
+        pre_timestamp = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
         pre_hash = hash_file(self.resource1_path)
 
-        result = mcp._upload_vm_resource(self.resource_file_name)
-        self.assertEqual(result, "no_date")
+        mc.upload_files()
 
-        upload_time = self.vm_resource_store.get_file_upload_date(
+        upload_timestamp = self.vm_resource_store.get_file_upload_date(
             self.resource_file_name
         )
         upload_hash = self.vm_resource_store.get_file_hash(self.resource_file_name)
-        self.assertEqual(upload_time, pre_time)
+        self.assertEqual(upload_timestamp, pre_timestamp)
         self.assertEqual(upload_hash, pre_hash)
 
-        # Sleep so we are sure we get a new time.
-        time.sleep(2)
+        # Rewrite the file after a delay to ensure a new timestamp
+        time.sleep(1)
         with open(self.resource1_path, "w", encoding="utf8") as fname:
             fname.write(self.resource1)
 
-        post_time = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
+        post_timestamp = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
         post_hash = hash_file(self.resource1_path)
-
-        self.assertNotEqual(pre_time, post_time)
-        self.assertTrue(upload_time < post_time)
+        self.assertTrue(pre_timestamp < post_timestamp)
+        self.assertTrue(upload_timestamp < post_timestamp)
         self.assertEqual(pre_hash, post_hash)
 
-        self.assertTrue(post_time > pre_time)
+        mc.upload_files()
 
-        result = mcp._upload_vm_resource(self.resource_file_name)
-        self.assertEqual(result, "same_hash")
+        new_upload_timestamp = self.vm_resource_store.get_file_upload_date(
+            self.resource_file_name
+        )
+        new_upload_hash = self.vm_resource_store.get_file_hash(self.resource_file_name)
+        self.assertEqual(new_upload_timestamp, upload_timestamp)
+        self.assertEqual(new_upload_hash, upload_hash)
 
-    def test_upload_new_time_new_hash(self):
-        mcp = ModelComponent(
+    def test_manifest_resource_upload_same_hash(self):
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
@@ -412,35 +428,89 @@ echo 'Hello, World!'
         pre_time = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
         pre_hash = hash_file(self.resource1_path)
 
-        result = mcp._upload_vm_resource(self.resource_file_name)
-        self.assertEqual(result, "no_date")
+        mc.upload_files()
 
-        upload_time = self.vm_resource_store.get_file_upload_date(
+    def test_upload_new_time_new_hash(self):
+        mc = ModelComponent(
+            path=self.mc_dir,
+            repository_db=self.repository_db,
+            vm_resource_store=self.vm_resource_store,
+        )
+
+        pre_timestamp = datetime.utcfromtimestamp(os.path.getmtime(self.resource1_path))
+        pre_hash = hash_file(self.resource1_path)
+
+        mc.upload_files()
+
+        upload_timestamp = self.vm_resource_store.get_file_upload_date(
             self.resource_file_name
         )
         upload_hash = self.vm_resource_store.get_file_hash(self.resource_file_name)
-        self.assertEqual(upload_time, pre_time)
+        self.assertEqual(upload_timestamp, pre_timestamp)
         self.assertEqual(upload_hash, pre_hash)
 
-        # Sleep so we are sure we get a new time.
-        time.sleep(2)
+        # Rewrite the file after a delay to ensure a new timestamp and new contents
+        time.sleep(1)
         with open(self.resource1_path, "w", encoding="utf8") as fname:
             fname.write("different contents")
 
-        post_time = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
+        post_timestamp = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
         post_hash = hash_file(self.resource1_path)
-
-        self.assertNotEqual(pre_time, post_time)
-        self.assertTrue(upload_time < post_time)
+        self.assertTrue(pre_timestamp < post_timestamp)
+        self.assertTrue(upload_timestamp < post_timestamp)
         self.assertNotEqual(pre_hash, post_hash)
 
-        self.assertTrue(post_time > pre_time)
+        mc.upload_files()
 
-        result = mcp._upload_vm_resource(self.resource_file_name)
+        new_upload_timestamp = self.vm_resource_store.get_file_upload_date(
+            self.resource_file_name
+        )
+        new_upload_hash = self.vm_resource_store.get_file_hash(self.resource_file_name)
+        self.assertNotEqual(new_upload_timestamp, upload_timestamp)
+        self.assertNotEqual(new_upload_hash, upload_hash)
+
+    def test_upload_old_time_new_hash(self):
+        mc = ModelComponent(
+            path=self.mc_dir,
+            repository_db=self.repository_db,
+            vm_resource_store=self.vm_resource_store,
+        )
+
+        subdir = "subdir"
+        second_vm_resource_path = os.path.join(
+            self.mc_dir, subdir, self.resource_file_name
+        )
+        os.makedirs(os.path.join(self.mc_dir, subdir))
+        time.sleep(1)
+        with open(second_vm_resource_path, "w", encoding="utf8") as fname:
+            fname.write("different contents")
+
+        second_time = datetime.utcfromtimestamp(os.path.getmtime(self.resource1_path))
+        second_hash = hash_file(second_vm_resource_path)
+
+        # Sleep so we are sure we get a new time.
+        time.sleep(1)
+
+        result = mc._upload_vm_resource(self.resource_file_name)
+        self.assertEqual(result, "no_date")
+
+        upload_time = self.vm_resource_store.get_file_upload_date(
+            self.resource_file_name
+        )
+        self.assertEqual(upload_time, second_time)
+
+        post_hash = hash_file(self.resource1_path)
+        store_hash = self.vm_resource_store.get_file_hash(self.resource_file_name)
+
+        self.assertEqual(store_hash, post_hash)
+        self.assertNotEqual(second_hash, post_hash)
+
+        result = mc._upload_vm_resource(os.path.join(subdir, self.resource_file_name))
         self.assertEqual(result, "new_hash")
+        assert False
 
     def test_upload_revert_same_file(self):
-        mcp = ModelComponent(
+        mc = ModelComponent(
             path=self.mc_dir,
             repository_db=self.repository_db,
             vm_resource_store=self.vm_resource_store,
@@ -449,7 +519,7 @@ echo 'Hello, World!'
         pre_time = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
         pre_hash = hash_file(self.resource1_path)
 
-        result = mcp._upload_vm_resource(self.resource_file_name)
+        result = mc._upload_vm_resource(self.resource_file_name)
         self.assertEqual(result, "no_date")
 
         upload_time = self.vm_resource_store.get_file_upload_date(
@@ -460,7 +530,7 @@ echo 'Hello, World!'
         self.assertEqual(upload_hash, pre_hash)
 
         # Sleep so we are sure we get a new time.
-        time.sleep(2)
+        time.sleep(1)
 
         # Move the file elsewhere
         tmp_path = tempfile.mkstemp()
@@ -479,7 +549,7 @@ echo 'Hello, World!'
 
         self.assertTrue(post_time > pre_time)
 
-        result = mcp._upload_vm_resource(self.resource_file_name)
+        result = mc._upload_vm_resource(self.resource_file_name)
         self.assertEqual(result, "new_hash")
         upload_time = self.vm_resource_store.get_file_upload_date(
             self.resource_file_name
@@ -487,7 +557,7 @@ echo 'Hello, World!'
         upload_hash = self.vm_resource_store.get_file_hash(self.resource_file_name)
 
         # Sleep so we are sure we get a new time.
-        time.sleep(2)
+        time.sleep(1)
 
         # Revert to previous file
         rev_time = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
@@ -510,245 +580,12 @@ echo 'Hello, World!'
         # And the file will be older than the reverted file
         self.assertTrue(rev_time > post_time)
 
-        result = mcp._upload_vm_resource(self.resource_file_name)
+        result = mc._upload_vm_resource(self.resource_file_name)
 
         # This should be uploaded because even though the time is "older" the contents
         # are newer.
         self.assertEqual(result, "new_hash")
-
-    def test_upload_old_time_new_hash(self):
-        mcp = ModelComponent(
-            path=self.mc_dir,
-            repository_db=self.repository_db,
-            vm_resource_store=self.vm_resource_store,
-        )
-
-        subdir = "subdir"
-        second_vm_resource_path = os.path.join(
-            self.mc_dir, subdir, self.resource_file_name
-        )
-        os.makedirs(os.path.join(self.mc_dir, subdir))
-        time.sleep(2)
-        with open(second_vm_resource_path, "w", encoding="utf8") as fname:
-            fname.write("different contents")
-
-        second_time = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
-        second_hash = hash_file(second_vm_resource_path)
-
-        # Sleep so we are sure we get a new time.
-        time.sleep(2)
-
-        result = mcp._upload_vm_resource(self.resource_file_name)
-        self.assertEqual(result, "no_date")
-
-        upload_time = self.vm_resource_store.get_file_upload_date(
-            self.resource_file_name
-        )
-        self.assertEqual(upload_time, second_time)
-
-        post_hash = hash_file(self.resource1_path)
-        store_hash = self.vm_resource_store.get_file_hash(self.resource_file_name)
-
-        self.assertEqual(store_hash, post_hash)
-        self.assertNotEqual(second_hash, post_hash)
-
-        result = mcp._upload_vm_resource(os.path.join(subdir, self.resource_file_name))
-        self.assertEqual(result, "new_hash")
-
-    def test_upload_from_manifest(self):
-        mcp = ModelComponent(
-            path=self.mc_dir,
-            repository_db=self.repository_db,
-            vm_resource_store=self.vm_resource_store,
-        )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
-
-        res = mcp._upload_vm_resources()
-        self.assertTrue(res)
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [self.resource_file_name])
-
-    def test_upload_vmr_string(self):
-        mcp = ModelComponent(
-            path=self.mc_dir,
-            repository_db=self.repository_db,
-            vm_resource_store=self.vm_resource_store,
-        )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
-
-        mcp.manifest["vm_resources"] = "string"
-        with self.assertRaises(RuntimeError):
-            mcp._upload_vm_resources()
-
-        try:
-            mcp._upload_vm_resources()
-        except RuntimeError as exp:
-            self.assertIn("must be a list", str(exp))
-
-    def test_upload_vmr_int(self):
-        mcp = ModelComponent(
-            path=self.mc_dir,
-            repository_db=self.repository_db,
-            vm_resource_store=self.vm_resource_store,
-        )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
-
-        mcp.manifest["vm_resources"] = 52
-        with self.assertRaises(RuntimeError):
-            mcp._upload_vm_resources()
-
-        try:
-            mcp._upload_vm_resources()
-        except RuntimeError as exp:
-            self.assertIn("must be a list", str(exp))
-
-    def test_upload_vmr_dict(self):
-        mcp = ModelComponent(
-            path=self.mc_dir,
-            repository_db=self.repository_db,
-            vm_resource_store=self.vm_resource_store,
-        )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
-
-        mcp.manifest["vm_resources"] = {}
-        with self.assertRaises(RuntimeError):
-            mcp._upload_vm_resources()
-
-        try:
-            mcp._upload_vm_resources()
-        except RuntimeError as exp:
-            self.assertIn("must be a list", str(exp))
-
-    def test_double_upload_from_manifest(self):
-        mcp = ModelComponent(
-            path=self.mc_dir,
-            repository_db=self.repository_db,
-            vm_resource_store=self.vm_resource_store,
-        )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
-
-        res = mcp._upload_vm_resources()
-        self.assertTrue(res)
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [self.resource_file_name])
-
-        res = mcp._upload_vm_resources()
-        self.assertFalse(res)
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [self.resource_file_name])
-
-    def test_upload_resource_one_not_another_from_manifest(self):
-        mcp = ModelComponent(
-            path=self.mc_dir,
-            repository_db=self.repository_db,
-            vm_resource_store=self.vm_resource_store,
-        )
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [])
-
-        result = mcp._upload_vm_resources()
-        self.assertTrue(result)
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        self.assertEqual(resource_list, [self.resource_file_name])
-        first_upload_date = self.vm_resource_store.get_file_upload_date(
-            self.resource_file_name
-        )
-
-        second_resource_name = "second_resource.sh"
-        second_resource_contents = "#!/bin/bash"
-        second_resource_path = os.path.join(self.mc_dir, second_resource_name)
-        time.sleep(1)
-        with open(second_resource_path, "w", encoding="utf8") as fname:
-            fname.write(second_resource_contents)
-
-        old_resource_list = mcp.manifest["vm_resources"]
-        mcp.manifest["vm_resources"] = [second_resource_name]
-        mcp.manifest["vm_resources"].extend(old_resource_list)
-
-        # Make sure we get different upload dates.
-        time.sleep(2)
-
-        result = mcp._upload_vm_resources()
-        self.assertTrue(result)
-
-        resource_list = self.vm_resource_store.list_contents()
-        resource_list = [resource[self.fn_key] for resource in resource_list]
-        resource_list.sort()
-        expected_list = [second_resource_name, self.resource_file_name]
-        expected_list.sort()
-
-        self.assertEqual(resource_list, expected_list)
-
-        second_upload_date = self.vm_resource_store.get_file_upload_date(
-            self.resource_file_name
-        )
-        second_resource_upload_date = self.vm_resource_store.get_file_upload_date(
-            second_resource_name
-        )
-        self.assertEqual(first_upload_date, second_upload_date)
-        self.assertNotEqual(second_upload_date, second_resource_upload_date)
-
-    def test_manifest_resource_upload_same_hash(self):
-        mcp = ModelComponent(
-            path=self.mc_dir,
-            repository_db=self.repository_db,
-            vm_resource_store=self.vm_resource_store,
-        )
-
-        pre_time = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
-        pre_hash = hash_file(self.resource1_path)
-
-        result = mcp._upload_vm_resources()
-        self.assertTrue(result)
-
-        upload_time = self.vm_resource_store.get_file_upload_date(
-            self.resource_file_name
-        )
-        upload_hash = self.vm_resource_store.get_file_hash(self.resource_file_name)
-        self.assertEqual(upload_time, pre_time)
-        self.assertEqual(upload_hash, pre_hash)
-
-        # Sleep so we are sure we get a new time.
-        time.sleep(2)
-        with open(self.resource1_path, "w", encoding="utf8") as fname:
-            fname.write(self.resource1)
-
-        post_time = datetime.fromtimestamp(os.path.getmtime(self.resource1_path), timezone.utc)
-        post_hash = hash_file(self.resource1_path)
-
-        self.assertNotEqual(pre_time, post_time)
-        self.assertTrue(upload_time < post_time)
-        self.assertEqual(pre_hash, post_hash)
-
-        self.assertTrue(post_time > pre_time)
-
-        result = mcp._upload_vm_resources()
-        self.assertFalse(result)
+        assert False
 
     def test_missing_required_exp(self):
         vm_resources = ["test.sh", "run.py"]


### PR DESCRIPTION
# Enhance progress outputs for image cache uploads

## Description
In service of improving the user experience of launching FIREWHEEL experiments, this MR begins adding more functionality to the `ModelComponent` and `ModelComponentManager` objects.

This MR contains a few substantive changes:
1. Most obvious to the user, the output from loading images to the image cache has been expanded. Images are grouped by MC, and while the load time continues to display independently per-image, the spinner is now associated with a progress output of the images to be loaded for any given MC. Also, large VM resources (over 250 MB) now also receive progress bars during upload.
2. The change described in (1) arose from needing to use a distinct layout of renderables from the rich library to separately display image cache upload progress, experiment graph progress (not implemented in this MR), experiment time progress (also not implemented in this MR), and the outputs of MC plugins. On the backend, that meant compartmentalizing image uploads to be represented by progress bars to match the [live progress](https://github.com/Textualize/rich/blob/master/examples/live_progress.py) example provided by rich, as well as adjusting some of the image handling to know before creating the progress bar whether an image would need updating.
3. In the process of accomplishing (2), the `ModelComponent` object was heavily refactored. It handled VM resources and images using very similar, but entirely separate upload processes. Now, it performs uploads in a uniform fashion, depending on the subtleties of each upload type defined via a new object class—a `_ModelComponentFile`. This object is notionally analagous to the existing `FileStoreFile` object from the `lib.minimega.file_store` module, but this represents the file as part of the model component rather than the file store. Ultimately, it seems like these file-like objects might do well to be combined eventually, but that feels like a separate issue.


## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.