### PR TITLE
fix: Adding a new fallback for the miniweb root to adjust to minimega v3.0.0

### DIFF
--- a/docs/source/tutorials/image/building_from_iso.rst
+++ b/docs/source/tutorials/image/building_from_iso.rst
@@ -131,7 +131,7 @@ Assuming minimega is installed at ``/opt/minimega``, to start the client, you ca
 
 .. code-block:: bash
 
-    $ cd /opt/minimega/misc/web/novnc
+    $ cd /opt/minimega/web/novnc
     $ ./utils/launch.sh
 
 This will launch a VNC client that you can connect to in a browser.

--- a/src/firewheel/cli/helpers/start
+++ b/src/firewheel/cli/helpers/start
@@ -49,10 +49,12 @@ if [ "$USE_GRE" = "True" ]; then
     $MINIMEGA_BIN -e ns bridge "$CONTROL_BRIDGE" gre
 fi
 
-if [ -d $MM_INSTALL_DIR/web/web ]; then
+if [ -d "$MM_INSTALL_DIR/web/web" ]; then
     MINIWEB_ROOT="$MM_INSTALL_DIR/web/web"
-else
+elif [ -d "$MM_INSTALL_DIR/misc/web" ]; then
     MINIWEB_ROOT="$MM_INSTALL_DIR/misc/web"
+else
+    MINIWEB_ROOT="$MM_INSTALL_DIR/web"
 fi
 
 MINIWEB_BIN="$MM_INSTALL_DIR/bin/miniweb -base=$MM_BASE_DIR -root=$MINIWEB_ROOT"


### PR DESCRIPTION
# fix: Updating the miniweb root directory

## Description
This addresses a "hack" that we put in place due to the misconfiguration and inconsistency of the miniweb root directory. See https://github.com/sandia-minimega/minimega/pull/1539 and https://github.com/sandia-minimega/minimega/pull/1549. I am leaving the inconsistent location checks (i.e., `web/web` and `misc/web`) for current backwards comparability, but these can/should be removed when a hard requirement on minimega v3.0 is enforced.

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.