### PR TITLE
refactor: VM State from a string to an Enum to enable better consistency

### DIFF
--- a/docs/source/install/configuration.rst
+++ b/docs/source/install/configuration.rst
@@ -265,10 +265,6 @@ These settings are used with FIREWHEEL's :ref:`vm-resource-manager`.
     +-------------------------------+----------+-----------------+-----------------------------------------------------------------------------------------------------------+
     |            Setting            |Value Type|     Default     |                                                Description                                                |
     +===============================+==========+=================+===========================================================================================================+
-    |.. _config-default_state:      |          |                 |                                                                                                           |
-    |                               |          |                 |                                                                                                           |
-    |``default_state``              |string    |``uninitialized``|The default *state* of VMs after they are launched.                                                        |
-    +-------------------------------+----------+-----------------+-----------------------------------------------------------------------------------------------------------+
     |.. _config-exp_start:          |          |                 |                                                                                                           |
     |                               |          |                 |                                                                                                           |
     |``experiment_start_buffer_sec``|int       |``60``           |The number of seconds after all experiment VMs have been configured to start :ref:`schedule-positive-time`.|

--- a/src/firewheel/config/config-template.yaml
+++ b/src/firewheel/config/config-template.yaml
@@ -50,5 +50,4 @@ test:
     vm_resource_store_test_database: testVmResourceDB
     vmmapping_test_database: testVmMappingDB
 vm_resource_manager:
-    default_state: uninitialized
     experiment_start_buffer_sec: 60

--- a/src/firewheel/control/model_component_dependency_graph.py
+++ b/src/firewheel/control/model_component_dependency_graph.py
@@ -173,8 +173,7 @@ class ModelComponentDependencyGraph(DependencyGraph):
         """
         cycle_graphs = [self._build_cycle_graph(cycle) for cycle in self.get_cycles()]
         cycle_graph_outputs = [
-            self._format_cycle_graph_output(cycle_graph)
-            for cycle_graph in cycle_graphs
+            self._format_cycle_graph_output(cycle_graph) for cycle_graph in cycle_graphs
         ]
         all_cycle_graphs = "\n\n".join(cycle_graph_outputs)
 

--- a/src/firewheel/lib/grpc/firewheel_grpc_client.py
+++ b/src/firewheel/lib/grpc/firewheel_grpc_client.py
@@ -6,6 +6,7 @@ from google.protobuf.timestamp_pb2 import Timestamp  # pylint: disable=no-name-i
 from firewheel.config import config
 from firewheel.lib.log import Log
 from firewheel.lib.grpc import firewheel_grpc_pb2, firewheel_grpc_pb2_grpc
+from firewheel.vm_resource_manager.vm_mapping import VMState
 from firewheel.lib.grpc.firewheel_grpc_resources import msg_to_dict
 
 
@@ -205,6 +206,47 @@ class FirewheelGrpcClient:
         response = msg_to_dict(response)
         return response
 
+    def _serialize_vm_mapping_state(self, vmm):
+        """
+        Convert a VMState enum in a VM mapping into its string value for transport.
+
+        Args:
+            vmm (dict): Dictionary representation of a VM mapping.
+
+        Returns:
+            dict: A copy of the VM mapping with ``state`` converted to its
+            string value when needed.
+        """
+        serialized = dict(vmm)
+        if "state" in serialized and isinstance(serialized["state"], VMState):
+            serialized["state"] = serialized["state"].value
+        return serialized
+
+    def _deserialize_vm_mapping_state(self, vmm):
+        """
+        Convert a serialized VM mapping state string back into a VMState enum.
+
+        Args:
+            vmm (dict): Dictionary representation of a VM mapping.
+
+        Returns:
+            dict: The VM mapping with ``state`` converted to ``VMState`` when
+            present.
+
+        Raises:
+            ValueError: If the ``state`` value is not a valid ``VMState``.
+        """
+        if not vmm or "state" not in vmm or vmm["state"] is None:
+            return vmm
+
+        state = vmm["state"]
+
+        if isinstance(state, VMState):
+            return vmm
+
+        vmm["state"] = VMState(state)
+        return vmm
+
     def destroy_all_vm_mappings(self):
         """
         Requests to destroy all `vm_mappings`.
@@ -223,12 +265,14 @@ class FirewheelGrpcClient:
         Requests to list all `vm_mappings`.
 
         Returns:
-            (list) Dictionary representations of `firewheel_grpc_pb2.VMMapping`.
+            list: Dictionary representations of `firewheel_grpc_pb2.VMMapping`
+            with ``state`` converted to ``VMState``.
         """
         req = firewheel_grpc_pb2.ListVMMappingsRequest(db=self.db)
 
         vm_mappings = self.stub.ListVMMappings(req)
         vm_mappings = [msg_to_dict(vmm) for vmm in vm_mappings]
+        vm_mappings = [self._deserialize_vm_mapping_state(vmm) for vmm in vm_mappings]
         return vm_mappings
 
     def set_vm_mapping(self, vmm):
@@ -239,28 +283,32 @@ class FirewheelGrpcClient:
             vmm (dict): Dictionary representation of vm_mapping.
 
         Returns:
-            (dict) Dictionary representation `firewheel_grpc_pb2.VMMapping`.
+            dict: Dictionary representation of `firewheel_grpc_pb2.VMMapping`
+            with ``state`` converted to ``VMState``.
         """
+        serialized = self._serialize_vm_mapping_state(vmm)
+
         mapping = firewheel_grpc_pb2.VMMapping(
-            server_uuid=vmm["server_uuid"],
-            server_name=vmm["server_name"],
-            control_ip=vmm["control_ip"],
-            state=vmm["state"],
-            current_time=vmm["current_time"],
+            server_uuid=serialized["server_uuid"],
+            server_name=serialized["server_name"],
+            control_ip=serialized["control_ip"],
+            state=serialized["state"],
+            current_time=serialized["current_time"],
             db=self.db,
         )
         resp = self.stub.SetVMMapping(mapping)
-        return msg_to_dict(resp)
+        return self._deserialize_vm_mapping_state(msg_to_dict(resp))
 
     def get_vm_mapping_by_uuid(self, vm_uuid):
         """
         Requests to get the vm_mapping corresponding to a given uuid.
 
         Args:
-            vm_uuid (str): vm uuid to search on.
+            vm_uuid (str): VM uuid to search on.
 
         Returns:
-            (dict) Dictionary representation `firewheel_grpc_pb2.VMMapping`.
+            dict: Dictionary representation of `firewheel_grpc_pb2.VMMapping`
+            with ``state`` converted to ``VMState``.
         """
         try:
             mapping = firewheel_grpc_pb2.VMMappingUUID(server_uuid=vm_uuid, db=self.db)
@@ -270,7 +318,7 @@ class FirewheelGrpcClient:
             if exp.exception().code() != grpc.StatusCode.OUT_OF_RANGE:
                 self.log.exception(exp)
             return None
-        return ret
+        return self._deserialize_vm_mapping_state(ret)
 
     def destroy_vm_mapping_by_uuid(self, vm_uuid):
         """

--- a/src/firewheel/lib/grpc/firewheel_grpc_client.py
+++ b/src/firewheel/lib/grpc/firewheel_grpc_client.py
@@ -6,7 +6,6 @@ from google.protobuf.timestamp_pb2 import Timestamp  # pylint: disable=no-name-i
 from firewheel.config import config
 from firewheel.lib.log import Log
 from firewheel.lib.grpc import firewheel_grpc_pb2, firewheel_grpc_pb2_grpc
-from firewheel.vm_resource_manager.vm_mapping import VMState
 from firewheel.lib.grpc.firewheel_grpc_resources import msg_to_dict
 
 
@@ -206,47 +205,6 @@ class FirewheelGrpcClient:
         response = msg_to_dict(response)
         return response
 
-    def _serialize_vm_mapping_state(self, vmm):
-        """
-        Convert a VMState enum in a VM mapping into its string value for transport.
-
-        Args:
-            vmm (dict): Dictionary representation of a VM mapping.
-
-        Returns:
-            dict: A copy of the VM mapping with ``state`` converted to its
-            string value when needed.
-        """
-        serialized = dict(vmm)
-        if "state" in serialized and isinstance(serialized["state"], VMState):
-            serialized["state"] = serialized["state"].value
-        return serialized
-
-    def _deserialize_vm_mapping_state(self, vmm):
-        """
-        Convert a serialized VM mapping state string back into a VMState enum.
-
-        Args:
-            vmm (dict): Dictionary representation of a VM mapping.
-
-        Returns:
-            dict: The VM mapping with ``state`` converted to ``VMState`` when
-            present.
-
-        Raises:
-            ValueError: If the ``state`` value is not a valid ``VMState``.
-        """
-        if not vmm or "state" not in vmm or vmm["state"] is None:
-            return vmm
-
-        state = vmm["state"]
-
-        if isinstance(state, VMState):
-            return vmm
-
-        vmm["state"] = VMState(state)
-        return vmm
-
     def destroy_all_vm_mappings(self):
         """
         Requests to destroy all `vm_mappings`.
@@ -265,14 +223,12 @@ class FirewheelGrpcClient:
         Requests to list all `vm_mappings`.
 
         Returns:
-            list: Dictionary representations of `firewheel_grpc_pb2.VMMapping`
-            with ``state`` converted to ``VMState``.
+            (list) Dictionary representations of `firewheel_grpc_pb2.VMMapping`.
         """
         req = firewheel_grpc_pb2.ListVMMappingsRequest(db=self.db)
 
         vm_mappings = self.stub.ListVMMappings(req)
         vm_mappings = [msg_to_dict(vmm) for vmm in vm_mappings]
-        vm_mappings = [self._deserialize_vm_mapping_state(vmm) for vmm in vm_mappings]
         return vm_mappings
 
     def set_vm_mapping(self, vmm):
@@ -283,32 +239,28 @@ class FirewheelGrpcClient:
             vmm (dict): Dictionary representation of vm_mapping.
 
         Returns:
-            dict: Dictionary representation of `firewheel_grpc_pb2.VMMapping`
-            with ``state`` converted to ``VMState``.
+            (dict) Dictionary representation `firewheel_grpc_pb2.VMMapping`.
         """
-        serialized = self._serialize_vm_mapping_state(vmm)
-
         mapping = firewheel_grpc_pb2.VMMapping(
-            server_uuid=serialized["server_uuid"],
-            server_name=serialized["server_name"],
-            control_ip=serialized["control_ip"],
-            state=serialized["state"],
-            current_time=serialized["current_time"],
+            server_uuid=vmm["server_uuid"],
+            server_name=vmm["server_name"],
+            control_ip=vmm["control_ip"],
+            state=vmm["state"],
+            current_time=vmm["current_time"],
             db=self.db,
         )
         resp = self.stub.SetVMMapping(mapping)
-        return self._deserialize_vm_mapping_state(msg_to_dict(resp))
+        return msg_to_dict(resp)
 
     def get_vm_mapping_by_uuid(self, vm_uuid):
         """
         Requests to get the vm_mapping corresponding to a given uuid.
 
         Args:
-            vm_uuid (str): VM uuid to search on.
+            vm_uuid (str): vm uuid to search on.
 
         Returns:
-            dict: Dictionary representation of `firewheel_grpc_pb2.VMMapping`
-            with ``state`` converted to ``VMState``.
+            (dict) Dictionary representation `firewheel_grpc_pb2.VMMapping`.
         """
         try:
             mapping = firewheel_grpc_pb2.VMMappingUUID(server_uuid=vm_uuid, db=self.db)
@@ -318,7 +270,7 @@ class FirewheelGrpcClient:
             if exp.exception().code() != grpc.StatusCode.OUT_OF_RANGE:
                 self.log.exception(exp)
             return None
-        return self._deserialize_vm_mapping_state(ret)
+        return ret
 
     def destroy_vm_mapping_by_uuid(self, vm_uuid):
         """

--- a/src/firewheel/lib/grpc/firewheel_grpc_server.py
+++ b/src/firewheel/lib/grpc/firewheel_grpc_server.py
@@ -13,6 +13,7 @@ from google.protobuf.json_format import Parse
 
 from firewheel.config import Config
 from firewheel.lib.log import Log
+from firewheel.vm_resource_manager.vm_mapping import VMState
 from firewheel.lib.grpc import firewheel_grpc_pb2, firewheel_grpc_pb2_grpc
 
 
@@ -118,7 +119,7 @@ class FirewheelServicer(firewheel_grpc_pb2_grpc.FirewheelServicer):
         self.dbs[db_name] = {}
         self.dbs[db_name] = {"vm_mappings": {}}
         self.dbs[db_name]["not_ready_vmms"] = set()
-        self.dbs[db_name]["ready_states"] = {"N/A", "configured"}
+        self.dbs[db_name]["ready_states"] = {VMState.NA.value, VMState.CONFIGURED.value}
         self.dbs[db_name]["experiment_start_times"] = []
         self.dbs[db_name]["experiment_launch_time"] = None
 

--- a/src/firewheel/lib/grpc/firewheel_grpc_server.py
+++ b/src/firewheel/lib/grpc/firewheel_grpc_server.py
@@ -13,8 +13,8 @@ from google.protobuf.json_format import Parse
 
 from firewheel.config import Config
 from firewheel.lib.log import Log
-from firewheel.vm_resource_manager.vm_mapping import VMState
 from firewheel.lib.grpc import firewheel_grpc_pb2, firewheel_grpc_pb2_grpc
+from firewheel.vm_resource_manager.vm_mapping import VMState
 
 
 class FirewheelServicer(firewheel_grpc_pb2_grpc.FirewheelServicer):

--- a/src/firewheel/tests/unit/vrm/test_vm_mapping.py
+++ b/src/firewheel/tests/unit/vrm/test_vm_mapping.py
@@ -322,7 +322,7 @@ class VMMappingTestCase(unittest.TestCase):
         self.vmmapping.set_vm_state_by_uuid(self.entries[1]["server_uuid"], new_state)
 
         found = self.vmmapping.get(server_uuid=self.entries[1]["server_uuid"])
-        self.assertEqual(found["state"], str(new_state))
+        self.assertEqual(found["state"], new_state)
 
     def test_set_vm_state_by_uuid_none(self):
         new_state = None

--- a/src/firewheel/tests/unit/vrm/test_vm_mapping.py
+++ b/src/firewheel/tests/unit/vrm/test_vm_mapping.py
@@ -1,7 +1,7 @@
 import unittest
 
 from firewheel.config import config
-from firewheel.vm_resource_manager.vm_mapping import VMMapping
+from firewheel.vm_resource_manager.vm_mapping import VMMapping, VMState
 
 
 class VMMappingTestCase(unittest.TestCase):
@@ -140,7 +140,7 @@ class VMMappingTestCase(unittest.TestCase):
             self.entries[1]["server_uuid"],
             self.entries[1]["server_name"],
             server_address=self.entries[1]["control_ip"],
-            state="configuring",
+            state=VMState.CONFIGURING,
             current_time=self.entries[1]["current_time"],
         )
         found = self.vmmapping.get(server_uuid=self.entries[1]["server_uuid"])
@@ -149,7 +149,7 @@ class VMMappingTestCase(unittest.TestCase):
             "control_ip": self.entries[1]["control_ip"],
             "server_uuid": self.entries[1]["server_uuid"],
             "server_name": self.entries[1]["server_name"],
-            "state": "configuring",
+            "state": VMState.CONFIGURING,
             "current_time": self.entries[1]["current_time"],
         }
         self.assertEqual(found, expected)
@@ -193,7 +193,7 @@ class VMMappingTestCase(unittest.TestCase):
                 "control_ip": self.entries[0]["control_ip"],
                 "server_uuid": self.entries[0]["server_uuid"],
                 "server_name": self.entries[0]["server_name"],
-                "state": config["vm_resource_manager"]["default_state"],
+                "state": VMState.UNINITIALIZED,
                 "current_time": "",
             }
         )
@@ -218,7 +218,7 @@ class VMMappingTestCase(unittest.TestCase):
             self.entries[1]["server_uuid"],
             self.entries[1]["server_name"],
             server_address=self.entries[1]["control_ip"],
-            state="configuring",
+            state=VMState.CONFIGURING,
             current_time=self.entries[1]["current_time"],
         )
 
@@ -244,7 +244,7 @@ class VMMappingTestCase(unittest.TestCase):
         self.vmmapping.put(
             "42",
             "decoy",
-            state=config["vm_resource_manager"]["default_state"],
+            state=VMState.UNINITIALIZED,
             current_time="0",
         )
 
@@ -270,7 +270,7 @@ class VMMappingTestCase(unittest.TestCase):
         )
 
         found = self.vmmapping.get(server_uuid=self.entries[1]["server_uuid"])
-        self.assertEqual(found["state"], config["vm_resource_manager"]["default_state"])
+        self.assertEqual(found["state"], VMState.UNINITIALIZED)
 
     def test_is_vm_state_default_custom(self):
         """
@@ -278,7 +278,7 @@ class VMMappingTestCase(unittest.TestCase):
         The default vm_resources state is determined in config, and
         defaults to "uninitialized".
         """
-        new_state = "testing"
+        new_state = VMState.TESTING
         self.vmmapping.put(
             self.entries[1]["server_uuid"],
             self.entries[1]["server_name"],
@@ -291,7 +291,7 @@ class VMMappingTestCase(unittest.TestCase):
         self.assertEqual(found["state"], new_state)
 
     def test_set_vm_state_by_uuid(self):
-        new_state = "testing"
+        new_state = VMState.TESTING
         self.vmmapping.put(
             self.entries[1]["server_uuid"],
             self.entries[1]["server_name"],
@@ -300,7 +300,7 @@ class VMMappingTestCase(unittest.TestCase):
         )
 
         found = self.vmmapping.get(server_uuid=self.entries[1]["server_uuid"])
-        self.assertEqual(found["state"], config["vm_resource_manager"]["default_state"])
+        self.assertEqual(found["state"], VMState.UNINITIALIZED)
 
         self.vmmapping.set_vm_state_by_uuid(self.entries[1]["server_uuid"], new_state)
 
@@ -308,7 +308,7 @@ class VMMappingTestCase(unittest.TestCase):
         self.assertEqual(found["state"], new_state)
 
     def test_set_vm_state_by_uuid_int(self):
-        new_state = 1234
+        new_state = VMState.TESTING
         self.vmmapping.put(
             self.entries[1]["server_uuid"],
             self.entries[1]["server_name"],
@@ -317,7 +317,7 @@ class VMMappingTestCase(unittest.TestCase):
         )
 
         found = self.vmmapping.get(server_uuid=self.entries[1]["server_uuid"])
-        self.assertEqual(found["state"], config["vm_resource_manager"]["default_state"])
+        self.assertEqual(found["state"], VMState.UNINITIALIZED)
 
         self.vmmapping.set_vm_state_by_uuid(self.entries[1]["server_uuid"], new_state)
 
@@ -334,7 +334,7 @@ class VMMappingTestCase(unittest.TestCase):
         )
 
         found = self.vmmapping.get(server_uuid=self.entries[1]["server_uuid"])
-        self.assertEqual(found["state"], config["vm_resource_manager"]["default_state"])
+        self.assertEqual(found["state"], VMState.UNINITIALIZED)
 
         self.vmmapping.set_vm_state_by_uuid(self.entries[1]["server_uuid"], new_state)
 
@@ -410,7 +410,7 @@ class VMMappingTestCase(unittest.TestCase):
         self.assertEqual(found["current_time"], new_time)
 
     def test_get_count_vm_not_ready(self):
-        new_state = "configured"
+        new_state = VMState.CONFIGURED
         self.vmmapping.put(
             self.entries[1]["server_uuid"],
             self.entries[1]["server_name"],

--- a/src/firewheel/tests/unit/vrm/test_vm_mapping.py
+++ b/src/firewheel/tests/unit/vrm/test_vm_mapping.py
@@ -25,7 +25,7 @@ class VMMappingTestCase(unittest.TestCase):
                 "server_name": "2",
                 "control_ip": "3",
                 "server_uuid": "12345",
-                "state": "testing",
+                "state": VMState.TESTING,
                 "current_time": "0",
             },
         ]

--- a/src/firewheel/tests/unit/vrm/test_vm_mapping.py
+++ b/src/firewheel/tests/unit/vrm/test_vm_mapping.py
@@ -25,7 +25,7 @@ class VMMappingTestCase(unittest.TestCase):
                 "server_name": "2",
                 "control_ip": "3",
                 "server_uuid": "12345",
-                "state": "test",
+                "state": "testing",
                 "current_time": "0",
             },
         ]
@@ -336,10 +336,8 @@ class VMMappingTestCase(unittest.TestCase):
         found = self.vmmapping.get(server_uuid=self.entries[1]["server_uuid"])
         self.assertEqual(found["state"], VMState.UNINITIALIZED)
 
-        self.vmmapping.set_vm_state_by_uuid(self.entries[1]["server_uuid"], new_state)
-
-        found = self.vmmapping.get(server_uuid=self.entries[1]["server_uuid"])
-        self.assertEqual(found["state"], None)
+        with self.assertRaises(ValueError):
+            self.vmmapping.set_vm_state_by_uuid(self.entries[1]["server_uuid"], new_state)
 
     def test_set_vm_time_by_uuid(self):
         new_time = "404"

--- a/src/firewheel/tests/unit/vrm/test_vrm_api.py
+++ b/src/firewheel/tests/unit/vrm/test_vrm_api.py
@@ -9,7 +9,7 @@ import pytest
 
 from firewheel.config import config
 from firewheel.vm_resource_manager import api
-from firewheel.vm_resource_manager.vm_mapping import VMMapping
+from firewheel.vm_resource_manager.vm_mapping import VMMapping, VMState
 from firewheel.vm_resource_manager.schedule_db import ScheduleDb
 from firewheel.vm_resource_manager.experiment_start import ExperimentStart
 from firewheel.vm_resource_manager.vm_resource_store import VmResourceStore
@@ -91,7 +91,7 @@ echo 'Hello, World!'
         )
         self.assertEqual(result["control_ip"], self.vmmapping_entries[0]["control_ip"])
         self.assertEqual(
-            result["state"], config["vm_resource_manager"]["default_state"]
+            result["state"], VMState.UNINITIALIZED
         )
 
     def test_add_vm_no_vm_resources(self):
@@ -154,7 +154,7 @@ echo 'Hello, World!'
         )
         self.assertEqual(
             states[self.vmmapping_entries[0]["server_name"]],
-            config["vm_resource_manager"]["default_state"],
+            VMState.UNINITIALIZED,
         )
 
     def test_get_vm_states_with_filter(self):

--- a/src/firewheel/tests/unit/vrm/test_vrm_api.py
+++ b/src/firewheel/tests/unit/vrm/test_vrm_api.py
@@ -23,7 +23,7 @@ class APITestCase(unittest.TestCase):
             {
                 "server_name": "2",
                 "control_ip": "3",
-                "state": "testing",
+                "state": VMState.TESTING,
                 "current_time": "0",
                 "server_uuid": "4321",
             },

--- a/src/firewheel/tests/unit/vrm/test_vrm_api.py
+++ b/src/firewheel/tests/unit/vrm/test_vrm_api.py
@@ -23,7 +23,7 @@ class APITestCase(unittest.TestCase):
             {
                 "server_name": "2",
                 "control_ip": "3",
-                "state": "test",
+                "state": "testing",
                 "current_time": "0",
                 "server_uuid": "4321",
             },
@@ -113,7 +113,7 @@ echo 'Hello, World!'
             result["server_name"], self.vmmapping_entries[0]["server_name"]
         )
         self.assertEqual(result["control_ip"], self.vmmapping_entries[0]["control_ip"])
-        self.assertEqual(result["state"], "N/A")
+        self.assertEqual(result["state"], VMState.NA)
 
     def test_get_vm_times(self):
         self.vmmapping.batch_put(self.vmmapping_entries)

--- a/src/firewheel/tests/unit/vrm/test_vrm_utils.py
+++ b/src/firewheel/tests/unit/vrm/test_vrm_utils.py
@@ -13,7 +13,7 @@ class UtilsTestCase(unittest.TestCase):
             {
                 "server_name": "2",
                 "control_ip": "3",
-                "state": "testing",
+                "state": VMState.TESTING,
                 "current_time": "0",
                 "server_uuid": "12345",
             },

--- a/src/firewheel/tests/unit/vrm/test_vrm_utils.py
+++ b/src/firewheel/tests/unit/vrm/test_vrm_utils.py
@@ -2,7 +2,7 @@ import unittest
 
 from firewheel.config import config
 from firewheel.vm_resource_manager import utils
-from firewheel.vm_resource_manager.vm_mapping import VMMapping
+from firewheel.vm_resource_manager.vm_mapping import VMMapping, VMState
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -13,7 +13,7 @@ class UtilsTestCase(unittest.TestCase):
             {
                 "server_name": "2",
                 "control_ip": "3",
-                "state": "test",
+                "state": "testing",
                 "current_time": "0",
                 "server_uuid": "12345",
             },
@@ -34,7 +34,7 @@ class UtilsTestCase(unittest.TestCase):
         pre = self.vmmapping.get(server_uuid=self.vmmapping_entries[1]["server_uuid"])
         self.assertNotEqual(pre, None)
 
-        new_state = "new_state"
+        new_state = VMState.FAILED
         utils.set_vm_state(
             self.vmmapping_entries[1]["server_uuid"], new_state, mapping=self.vmmapping
         )
@@ -47,7 +47,7 @@ class UtilsTestCase(unittest.TestCase):
 
     def test_vm_state_invalid(self):
         with self.assertRaises(RuntimeError):
-            utils.set_vm_state("invalid", "new_state", mapping=self.vmmapping)
+            utils.set_vm_state("invalid", VMState.FAILED, mapping=self.vmmapping)
 
     def test_vm_time_update(self):
         pre = self.vmmapping.get(server_uuid=self.vmmapping_entries[1]["server_uuid"])
@@ -74,8 +74,8 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(count, len(self.vmmapping_entries))
 
     def test_not_ready_count_with_ready(self):
-        self.vmmapping.put("5", "ready1", state="configured")
-        self.vmmapping.put("6", "noresources1", state="N/A")
+        self.vmmapping.put("5", "ready1", state=VMState.CONFIGURED)
+        self.vmmapping.put("6", "noresources1", state=VMState.NA)
 
         count = utils.get_vm_count_not_ready(mapping=self.vmmapping)
         self.assertEqual(count, len(self.vmmapping_entries))

--- a/src/firewheel/vm_resource_manager/api.py
+++ b/src/firewheel/vm_resource_manager/api.py
@@ -4,8 +4,7 @@ functions should be callable with only information available from experiment
 *Control*.
 """
 
-from firewheel.config import config
-from firewheel.vm_resource_manager.vm_mapping import VMMapping, VMState
+from firewheel.vm_resource_manager.vm_mapping import VMState, VMMapping
 from firewheel.vm_resource_manager.schedule_db import ScheduleDb
 from firewheel.vm_resource_manager.experiment_start import ExperimentStart
 from firewheel.vm_resource_manager.vm_resource_store import VmResourceStore
@@ -34,7 +33,7 @@ def add_vm(
     if use_vm_manager:
         state = VMState.UNINITIALIZED
     else:
-         state = VMState.NA
+        state = VMState.NA
 
     close = False
     if mapping is None:

--- a/src/firewheel/vm_resource_manager/api.py
+++ b/src/firewheel/vm_resource_manager/api.py
@@ -5,7 +5,7 @@ functions should be callable with only information available from experiment
 """
 
 from firewheel.config import config
-from firewheel.vm_resource_manager.vm_mapping import VMMapping
+from firewheel.vm_resource_manager.vm_mapping import VMMapping, VMState
 from firewheel.vm_resource_manager.schedule_db import ScheduleDb
 from firewheel.vm_resource_manager.experiment_start import ExperimentStart
 from firewheel.vm_resource_manager.vm_resource_store import VmResourceStore
@@ -32,9 +32,9 @@ def add_vm(
         log (logging.Logger): An optional logger that can to output results.
     """
     if use_vm_manager:
-        state = config["vm_resource_manager"]["default_state"]
+        state = VMState.UNINITIALIZED
     else:
-        state = "N/A"
+         state = VMState.NA
 
     close = False
     if mapping is None:

--- a/src/firewheel/vm_resource_manager/utils.py
+++ b/src/firewheel/vm_resource_manager/utils.py
@@ -98,7 +98,7 @@ def get_vm_count_not_ready(mapping=None, log=None):
         log (logging.Logger): An optional logger that can to output results.
 
     Returns:
-        str: Count of the number of VMs not in the "configured" or
+        str: Count of the number of VMs not in the "VMState.CONFIGURED" or
              "N/A" vm_resources state.
     """
     close = False

--- a/src/firewheel/vm_resource_manager/utils.py
+++ b/src/firewheel/vm_resource_manager/utils.py
@@ -99,7 +99,7 @@ def get_vm_count_not_ready(mapping=None, log=None):
 
     Returns:
         str: Count of the number of VMs not in the "VMState.CONFIGURED" or
-             "N/A" vm_resources state.
+             "VMState.NA" vm_resources state.
     """
     close = False
     if mapping is None:

--- a/src/firewheel/vm_resource_manager/vm_mapping.py
+++ b/src/firewheel/vm_resource_manager/vm_mapping.py
@@ -155,6 +155,7 @@ class VMMapping:
             raise ValueError("Must provide server_uuid")
 
         return self._deserialize_vm_mapping_state(vmm)
+
     def get_all(
         self, filter_time=None, filter_state=None, project_dict=None, length=False
     ):
@@ -202,7 +203,10 @@ class VMMapping:
                         continue
                 else:
                     filter_text = str(filter_state).lower()
-                    if filter_text not in state.value.lower() and filter_text not in state.name.lower():
+                    if (
+                        filter_text not in state.value.lower()
+                        and filter_text not in state.name.lower()
+                    ):
                         continue
 
             ret.append(vmm)

--- a/src/firewheel/vm_resource_manager/vm_mapping.py
+++ b/src/firewheel/vm_resource_manager/vm_mapping.py
@@ -91,6 +91,45 @@ class VMMapping:
         """
         self.grpc_client.close()
 
+    def _serialize_vm_mapping_state(self, vmm):
+        """
+        Convert a VMState enum in a VM mapping into its string value for transport.
+
+        Args:
+            vmm (dict): Dictionary representation of a VM mapping.
+
+        Returns:
+            dict: A copy of the VM mapping with ``state`` converted to its
+            string value when needed.
+        """
+        serialized = dict(vmm)
+        if "state" in serialized and isinstance(serialized["state"], VMState):
+            serialized["state"] = serialized["state"].value
+        return serialized
+
+    def _deserialize_vm_mapping_state(self, vmm):
+        """
+        Convert a serialized VM mapping state string back into a VMState enum.
+
+        Args:
+            vmm (dict): Dictionary representation of a VM mapping.
+
+        Returns:
+            dict: The VM mapping with ``state`` converted to ``VMState`` when
+            present.
+        """
+        if not vmm or "state" not in vmm or vmm["state"] is None:
+            return vmm
+
+        deserialized = dict(vmm)
+        state = deserialized["state"]
+
+        if isinstance(state, VMState):
+            return deserialized
+
+        deserialized["state"] = VMState(state)
+        return deserialized
+
     def get(self, server_uuid=None):
         """
         Retrieve a single entry from the database. This can only retrieve
@@ -110,7 +149,8 @@ class VMMapping:
             vmm = self.grpc_client.get_vm_mapping_by_uuid(server_uuid)
         else:
             raise ValueError("Must provide server_uuid")
-        return vmm
+
+        return self._deserialize_vm_mapping_state(vmm)
 
     def get_all(
         self, filter_time=None, filter_state=None, project_dict=None, length=False
@@ -126,7 +166,7 @@ class VMMapping:
         Args:
             filter_time (int): Only return VM information when the current
                                relative time matches this value.
-            filter_state (str): Only return VM information when the current
+            filter_state (str | VMState): Only return VM information when the current
                                 vm resource state matches this value.
             project_dict (dict): Only return VM information from these keys.
             length (bool): Should the function return how many VMs are in the list
@@ -137,19 +177,24 @@ class VMMapping:
             dictionary is the same as would be returned for the VM if retrieved
             using `get()`. If length is `True`, returns the length of the list.
         """
-
         if not project_dict:
             project_dict = {"_id": 0}
 
         vmms = self.grpc_client.list_vm_mappings()
         ret = []
 
+        if filter_state is not None:
+            filter_state = VMState(filter_state)
+
         for vmm in vmms:
+            vmm = self._deserialize_vm_mapping_state(vmm)
+
             if filter_time and vmm["current_time"] != filter_time:
                 continue
-            if filter_state and filter_state not in vmm["state"]:
+            if filter_state is not None and vmm["state"] != filter_state:
                 continue
             ret.append(vmm)
+
         if length:
             return len(ret)
 
@@ -169,11 +214,14 @@ class VMMapping:
         Args:
             server_uuid (str): UUID of the VM.
             server_name (str): Hostname of the VM.
-            state (VMState): Vm Resource state the VM starts in. Defaults to :py:attr:`VMState.UNINITIALIZED`.
+            state (VMState | str): Vm Resource state the VM starts in.
+                Defaults to :py:attr:`VMState.UNINITIALIZED`.
             current_time (str): The current (relative) time for the VM.
                 Defaults to '', meaning the VM has not contacted the server yet.
             server_address (str): The `control_ip` of the host where the VM Resource is found.
         """
+        state = VMState(state)
+
         document = {
             "server_uuid": server_uuid,
             "server_name": server_name,
@@ -181,7 +229,7 @@ class VMMapping:
             "current_time": current_time,
             "control_ip": server_address,
         }
-        self.grpc_client.set_vm_mapping(document)
+        self.grpc_client.set_vm_mapping(self._serialize_vm_mapping_state(document))
 
     def set_vm_state_by_uuid(self, uuid, state):
         """
@@ -189,14 +237,17 @@ class VMMapping:
 
         Args:
             uuid (str): UUID of the VM.
-            state (VMState): The new state for the VM.
+            state (VMState | str): The new state for the VM.
 
         Returns:
             dict: Dictionary representation of the updated `firewheel_grpc_pb2.VMMapping`.
         """
+        state = VMState(state)
         vmm = {"server_uuid": uuid, "state": state}
-        ret = self.grpc_client.set_vm_state_by_uuid(vmm)
-        return ret
+        ret = self.grpc_client.set_vm_state_by_uuid(
+            self._serialize_vm_mapping_state(vmm)
+        )
+        return self._deserialize_vm_mapping_state(ret)
 
     def set_vm_time_by_uuid(self, uuid, time):
         """
@@ -211,7 +262,7 @@ class VMMapping:
         """
         vmm = {"server_uuid": uuid, "current_time": time}
         ret = self.grpc_client.set_vm_time_by_uuid(vmm)
-        return ret
+        return self._deserialize_vm_mapping_state(ret)
 
     def get_count_vm_not_ready(self):
         """
@@ -266,7 +317,7 @@ class VMMapping:
         if "state" not in entry:
             new_entry["state"] = VMState.UNINITIALIZED
         else:
-            new_entry["state"] = entry["state"]
+            new_entry["state"] = VMState(entry["state"])
 
         if "current_time" not in entry:
             new_entry["current_time"] = ""
@@ -281,7 +332,7 @@ class VMMapping:
 
     def batch_put(self, server_list):
         """
-        Add a list of VM information  to the database as a batch update. Each
+        Add a list of VM information to the database as a batch update. Each
         entry in the list is a dictionary specifying the relevant information.
 
         Args:
@@ -300,7 +351,6 @@ class VMMapping:
                                 Only `server_uuid` and `server_name` fields are
                                 required for each entry in the list.
         """
-        # Avoid polluting the up-stream data structures.
         for entry in server_list:
             new_entry = self.prepare_put(entry)
             self.put(

--- a/src/firewheel/vm_resource_manager/vm_mapping.py
+++ b/src/firewheel/vm_resource_manager/vm_mapping.py
@@ -2,11 +2,37 @@
 Interface to the mapping between VMs, their current (vm resource) state, and other
 metadata.
 """
-
+from enum import Enum
 from firewheel.config import config
 from firewheel.lib.log import Log
 from firewheel.lib.grpc.firewheel_grpc_client import FirewheelGrpcClient
 
+
+class VMState(str, Enum):
+    """
+    Valid virtual machine lifecycle states.
+
+    This enum defines the allowed values that may be reported to the
+    infrastructure through ``set_state()``. Each enum member uses a
+    string value so it can be passed directly to APIs, logging, and
+    comparisons without needing additional conversion.
+
+    States:
+        CONFIGURING:
+            The VM is currently being configured.
+
+        CONFIGURED:
+            The VM configuration has completed successfully. When all
+            VMs reach this state, the experiment start time may be set.
+
+        FAILED:
+            The VM failed during configuration or could not reach the
+            configured state.
+    """
+
+    CONFIGURING = "configuring"
+    CONFIGURED = "configured"
+    FAILED = "failed"
 
 class VMMapping:
     """

--- a/src/firewheel/vm_resource_manager/vm_mapping.py
+++ b/src/firewheel/vm_resource_manager/vm_mapping.py
@@ -2,7 +2,9 @@
 Interface to the mapping between VMs, their current (vm resource) state, and other
 metadata.
 """
+
 from enum import Enum
+
 from firewheel.config import config
 from firewheel.lib.log import Log
 from firewheel.lib.grpc.firewheel_grpc_client import FirewheelGrpcClient
@@ -33,6 +35,7 @@ class VMState(str, Enum):
     CONFIGURING = "configuring"
     CONFIGURED = "configured"
     FAILED = "failed"
+
 
 class VMMapping:
     """

--- a/src/firewheel/vm_resource_manager/vm_mapping.py
+++ b/src/firewheel/vm_resource_manager/vm_mapping.py
@@ -20,6 +20,9 @@ class VMState(str, Enum):
     comparisons without needing additional conversion.
 
     States:
+        UNINITIALIZED:
+            The VM has not yet contacted the server or been set to any state.
+    
         CONFIGURING:
             The VM is currently being configured.
 
@@ -30,11 +33,16 @@ class VMState(str, Enum):
         FAILED:
             The VM failed during configuration or could not reach the
             configured state.
-    """
 
+        TESTING:
+            The VM is currently running tests. This is a user-defined state that may be used
+            as desired, but it is not used by the VRM system itself.
+    """
+    UNINITIALIZED = "uninitialized"
     CONFIGURING = "configuring"
     CONFIGURED = "configured"
     FAILED = "failed"
+    TESTING = "testing"
 
 
 class VMMapping:
@@ -150,7 +158,7 @@ class VMMapping:
         self,
         server_uuid,
         server_name,
-        state=config["vm_resource_manager"]["default_state"],
+        state=VMState.UNINITIALIZED,
         current_time="",
         server_address="",
     ):
@@ -160,13 +168,10 @@ class VMMapping:
         Args:
             server_uuid (str): UUID of the VM.
             server_name (str): Hostname of the VM.
-            state (str): Vm Resource state the VM starts in. Defaults to the
-                         configured default state (located in the FIREWHEEL configuration).
+            state (VMState): Vm Resource state the VM starts in. Defaults to :py:attr:`VMState.UNINITIALIZED`.
             current_time (str): The current (relative) time for the VM.
-                                Defaults to '', meaning the VM has not contacted the
-                                server yet.
-            server_address (str): The `control_ip` of the host where the VM Resource
-                                  is found.
+                Defaults to '', meaning the VM has not contacted the server yet.
+            server_address (str): The `control_ip` of the host where the VM Resource is found.
         """
         document = {
             "server_uuid": server_uuid,
@@ -183,7 +188,7 @@ class VMMapping:
 
         Args:
             uuid (str): UUID of the VM.
-            state (str): The new state for the VM.
+            state (VMState): The new state for the VM.
 
         Returns:
             dict: Dictionary representation of the updated `firewheel_grpc_pb2.VMMapping`.
@@ -258,7 +263,7 @@ class VMMapping:
         }
 
         if "state" not in entry:
-            new_entry["state"] = config["vm_resource_manager"]["default_state"]
+            new_entry["state"] = VMState.UNINITIALIZED
         else:
             new_entry["state"] = entry["state"]
 

--- a/src/firewheel/vm_resource_manager/vm_mapping.py
+++ b/src/firewheel/vm_resource_manager/vm_mapping.py
@@ -22,7 +22,7 @@ class VMState(str, Enum):
     States:
         UNINITIALIZED:
             The VM has not yet contacted the server or been set to any state.
-    
+
         CONFIGURING:
             The VM is currently being configured.
 
@@ -38,6 +38,7 @@ class VMState(str, Enum):
             The VM is currently running tests. This is a user-defined state that may be used
             as desired, but it is not used by the VRM system itself.
     """
+
     UNINITIALIZED = "uninitialized"
     CONFIGURING = "configuring"
     CONFIGURED = "configured"

--- a/src/firewheel/vm_resource_manager/vm_mapping.py
+++ b/src/firewheel/vm_resource_manager/vm_mapping.py
@@ -23,6 +23,9 @@ class VMState(str, Enum):
         UNINITIALIZED:
             The VM has not yet contacted the server or been set to any state.
 
+        NA:
+            The VM Resource Manager is not used for this VM.
+
         CONFIGURING:
             The VM is currently being configured.
 
@@ -40,6 +43,7 @@ class VMState(str, Enum):
     """
 
     UNINITIALIZED = "uninitialized"
+    NA = "n/a"
     CONFIGURING = "configuring"
     CONFIGURED = "configured"
     FAILED = "failed"
@@ -151,7 +155,6 @@ class VMMapping:
             raise ValueError("Must provide server_uuid")
 
         return self._deserialize_vm_mapping_state(vmm)
-
     def get_all(
         self, filter_time=None, filter_state=None, project_dict=None, length=False
     ):
@@ -167,7 +170,9 @@ class VMMapping:
             filter_time (int): Only return VM information when the current
                                relative time matches this value.
             filter_state (str | VMState): Only return VM information when the current
-                                vm resource state matches this value.
+                               vm resource state matches this value. If a string is
+                               provided, substring matching is used against the
+                               serialized enum value.
             project_dict (dict): Only return VM information from these keys.
             length (bool): Should the function return how many VMs are in the list
                            or should it return the list itself.
@@ -183,16 +188,23 @@ class VMMapping:
         vmms = self.grpc_client.list_vm_mappings()
         ret = []
 
-        if filter_state is not None:
-            filter_state = VMState(filter_state)
-
         for vmm in vmms:
             vmm = self._deserialize_vm_mapping_state(vmm)
 
             if filter_time and vmm["current_time"] != filter_time:
                 continue
-            if filter_state is not None and vmm["state"] != filter_state:
-                continue
+
+            if filter_state is not None:
+                state = vmm["state"]
+
+                if isinstance(filter_state, VMState):
+                    if state != filter_state:
+                        continue
+                else:
+                    filter_text = str(filter_state).lower()
+                    if filter_text not in state.value.lower() and filter_text not in state.name.lower():
+                        continue
+
             ret.append(vmm)
 
         if length:

--- a/src/firewheel/vm_resource_manager/vm_resource_handler.py
+++ b/src/firewheel/vm_resource_manager/vm_resource_handler.py
@@ -300,7 +300,8 @@ class VMResourceHandler:
 
                         thread_target = (
                             self.run_vm_resource_host
-                            if schedule_entry.on_host else self.run_vm_resource
+                            if schedule_entry.on_host
+                            else self.run_vm_resource
                         )
                         thread = Thread(target=thread_target, kwargs=kwargs)
 

--- a/src/firewheel/vm_resource_manager/vm_resource_handler.py
+++ b/src/firewheel/vm_resource_manager/vm_resource_handler.py
@@ -28,7 +28,7 @@ from firewheel.lib.log import UTCLog
 from firewheel.lib.minimega.api import minimegaAPI
 from firewheel.vm_resource_manager import api, utils
 from firewheel.control.repository_db import RepositoryDb
-from firewheel.vm_resource_manager.vm_mapping import VMMapping, VMState
+from firewheel.vm_resource_manager.vm_mapping import VMState, VMMapping
 from firewheel.vm_resource_manager.schedule_db import ScheduleDb
 from firewheel.vm_resource_manager.schedule_event import (
     ScheduleEvent,
@@ -338,7 +338,8 @@ class VMResourceHandler:
                         # the vm_resource
                         timer_target = (
                             self.run_vm_resource_host
-                            if schedule_entry.on_host else self.run_vm_resource
+                            if schedule_entry.on_host
+                            else self.run_vm_resource
                         )
                         thread = Timer(delay, timer_target, args=(schedule_entry,))
                         # Positive time vm_resources don't get held onto since
@@ -1428,7 +1429,7 @@ class VMResourceHandler:
          If the new state is ``VMState.CONFIGURED``, then check whether this
         VM is the last VM to be configured. If it is, set the experiment
         start time.
-        
+
         State transition rule(s):
         - Once a VM reaches ``VMState.CONFIGURED``, it may only transition
           to ``VMState.FAILED``. Attempts to move from ``configured`` back

--- a/src/firewheel/vm_resource_manager/vm_resource_handler.py
+++ b/src/firewheel/vm_resource_manager/vm_resource_handler.py
@@ -1441,7 +1441,7 @@ class VMResourceHandler:
           to ``configuring`` are ignored.
 
         Args:
-            state: Desired state of the VM as a ``VMState``.
+            state (VMState): Desired state of the VM.
         """
         current_state = VMState(self.state) if self.state is not None else None
 
@@ -1466,6 +1466,7 @@ class VMResourceHandler:
         except RuntimeError as exp:
             self.log.error("Error setting VM state. Can not set state to: %s", state)
             self.log.exception(exp)
+            return
 
         # Check to see if the experiment start time can be set
         if state == VMState.CONFIGURED:

--- a/src/firewheel/vm_resource_manager/vm_resource_handler.py
+++ b/src/firewheel/vm_resource_manager/vm_resource_handler.py
@@ -28,7 +28,7 @@ from firewheel.lib.log import UTCLog
 from firewheel.lib.minimega.api import minimegaAPI
 from firewheel.vm_resource_manager import api, utils
 from firewheel.control.repository_db import RepositoryDb
-from firewheel.vm_resource_manager.vm_mapping import VMMapping
+from firewheel.vm_resource_manager.vm_mapping import VMMapping, VMState
 from firewheel.vm_resource_manager.schedule_db import ScheduleDb
 from firewheel.vm_resource_manager.schedule_event import (
     ScheduleEvent,
@@ -163,7 +163,7 @@ class VMResourceHandler:
         connected = self.connect_to_driver()
 
         if connected:
-            self.set_state("configuring")
+            self.set_state(VMState.CONFIGURING)
         else:
             sys.exit(1)
 
@@ -256,7 +256,7 @@ class VMResourceHandler:
                     # need to pass the global barrier
                     self.log.debug("PROCESSING NO SCHEDULE EVENT")
                     self.current_time = 0
-                    self.set_state("configured")
+                    self.set_state(VMState.CONFIGURED)
 
                 elif event.get_type() == ScheduleEventType.NEW_ITEM:
                     self.log.debug("PROCESSING NEW ITEM EVENT")
@@ -278,7 +278,7 @@ class VMResourceHandler:
                             # (e.g. push file) where we don't want the VM resource
                             # handler to exit on failure
                             if not schedule_entry.ignore_failure:
-                                self.set_state("FAILED")
+                                self.set_state(VMState.FAILED)
                                 sys.exit(1)
 
                     if not schedule_entry.executable:
@@ -1109,7 +1109,7 @@ class VMResourceHandler:
             if self.current_time < 0 and self.current_time > self.initial_time:
                 self.current_time = 0
                 self.set_current_time(self.current_time)
-                self.set_state("configured")
+                self.set_state(VMState.CONFIGURED)
 
             self.log.debug("Event queue is empty, WAITING")
             self.condition.wait()
@@ -1152,7 +1152,7 @@ class VMResourceHandler:
                 self.prior_q.put((start_time, event))
 
                 # All negative time vm_resources have been handled
-                self.set_state("configured")
+                self.set_state(VMState.CONFIGURED)
                 self.current_time = 0
                 self.set_current_time(self.current_time)
 
@@ -1422,19 +1422,39 @@ class VMResourceHandler:
             return issubclass(obj, AbstractDriver) and not inspect.isabstract(obj)
         return False
 
-    def set_state(self, state):
+    def set_state(self, state: VMState):
         """
         Tell the infrastructure the state of the VM.
-        If the state is 'configured', then check to see
-        if this VM is the last VM to be configured. If it
-        is the last VM to be configured, then set the
-        experiment start time.
+         If the new state is ``VMState.CONFIGURED``, then check whether this
+        VM is the last VM to be configured. If it is, set the experiment
+        start time.
+        
+        State transition rule(s):
+        - Once a VM reaches ``VMState.CONFIGURED``, it may only transition
+          to ``VMState.FAILED``. Attempts to move from ``configured`` back
+          to ``configuring`` are ignored.
 
         Args:
-            state (str): State of the VM
+            state: Desired state of the VM as either a ``VMState`` or a
+                valid string.
+
+        Raises:
+            ValueError: If ``state`` is not a valid ``VMState`` value.
         """
-        if self.state == state:
+        current_state = VMState(self.state) if self.state is not None else None
+
+        if current_state == state:
             return
+
+        # Once configured, the VM may only transition to failed.
+        if current_state == VMState.CONFIGURED and state != VMState.FAILED:
+            self.log.warning(
+                "Ignoring invalid VM state transition from %s to %s",
+                current_state.value,
+                state.value,
+            )
+            return
+
         try:
             self.log.debug("SETTING STATE: %s", state)
             utils.set_vm_state(
@@ -1446,7 +1466,7 @@ class VMResourceHandler:
             self.log.exception(exp)
 
         # Check to see if the experiment start time can be set
-        if state == "configured":
+        if state == VMState.CONFIGURED:
             if self.experiment_start_time:
                 return
             not_ready_count = utils.get_vm_count_not_ready(

--- a/src/firewheel/vm_resource_manager/vm_resource_handler.py
+++ b/src/firewheel/vm_resource_manager/vm_resource_handler.py
@@ -1441,11 +1441,7 @@ class VMResourceHandler:
           to ``configuring`` are ignored.
 
         Args:
-            state: Desired state of the VM as either a ``VMState`` or a
-                valid string.
-
-        Raises:
-            ValueError: If ``state`` is not a valid ``VMState`` value.
+            state: Desired state of the VM as a ``VMState``.
         """
         current_state = VMState(self.state) if self.state is not None else None
 


### PR DESCRIPTION
# Refactor: VM State from a string to an Enum to enable better consistency

## Description
This pull request introduces a new `VMState` enum to replace raw VM state strings with well-defined, meaningful string values:

- `uninitialized`
- `configuring`
- `configured`
- `failed`
- `testing`

The `set_state()` method was updated to use this enum and now enforces a state transition rule for already-configured VMs. Once a VM reaches the `configured` state, it may only transition to `failed`. Attempts to transition from `configured` back to `configuring` are ignored and logged as invalid transitions.

This change improves code readability, reduces the risk of string typos, and ensures VM state progression follows the intended lifecycle semantics.

In addition, we have updated all related tests and removed the ability for users to set their own "default" state. This was a never-used feature and should be consistent across all FIREWHEEL installations so that there is a consistent understanding of VM states.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe): Refactor

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.