### PR TITLE
chore: Fix typo in README intro sentence

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ FIREWHEEL
 
 .. readme-inclusion-marker
 
-FIREWHEEL is an experiment orchestration tool that assists a user in building and controlling, repeatable experiments of distributed network systems at any scale.
+FIREWHEEL is an experiment orchestration tool that assists a user in building and controlling repeatable experiments of distributed network systems at any scale.
 
 FIREWHEEL was developed as part of Sandia National Laboratories `Emulytics <https://www.sandia.gov/emulytics>`_ program.
 With FIREWHEEL, users can easily construct modular parts of a cyber system, called *Model Components*.


### PR DESCRIPTION
<!-- The title of the PR should be in conventional commit format -->
<!-- Remember this title will end up as the merge commit subject -->

## Description
Fix an extra comma that has apparently made it's way into most of our repo descriptions.

### Motivation and context ###
A recent repository viewer brought to our attention that the repo description had an unnecessary comma. I corrected that issue in the repo description, but it appears that the phrase is a copy/paste from our README (which is also used to build the docs).

## Type of Change ##
<!-- Please uncomment the type of change your pull request introduces: -->
<!-- - Bugfix -->
<!-- - New feature -->
Documentation update
<!-- - Other (please describe): -->

## Checklist ##
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] A human has performed a self-review of my code.
- ~I have commented my code, particularly in hard-to-understand areas.~ 
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- ~I have tested my code with the functional test suite, and it passed.~