### PR TITLE
feat: Update key subset of helpers to provide JSON output

### DIFF
--- a/src/firewheel/cli/helpers/experiment
+++ b/src/firewheel/cli/helpers/experiment
@@ -97,12 +97,16 @@ DONE
 RUN LocalPython ON control
 #!/usr/bin/env python
 
+import os
+import io
 import sys
+import json
 import errno
 import argparse
 import cProfile
 import traceback
-from datetime import datetime
+import tempfile
+from datetime import datetime, timezone
 
 from rich.align import Align
 from rich.console import Console
@@ -116,19 +120,209 @@ from firewheel.control.dependency_graph import UnsatisfiableDependenciesError
 from firewheel.control.model_component_manager import ModelComponentManager
 
 
-def get_mc_list(cli_args, install_mcs=None):
-    """
-    Get the list of model components and their arguments from the command line.
+class ExperimentHelperError(Exception):
+    """Expected operational error for the experiment helper.
 
     Args:
-        cli_args (list): A list of command line-input model components.
-        install_mcs (bool): A flag indicating whether to install model components automatically.
+        message (str): Human-readable error message.
+        error_type (str): Stable machine-readable error type.
+        phase (str): Phase in which the error occurred.
+    """
+
+    def __init__(self, message, error_type, phase):
+        """Initialize the exception.
+
+        Args:
+            message (str): Human-readable error message.
+            error_type (str): Stable machine-readable error type.
+            phase (str): Phase in which the error occurred.
+        """
+        super().__init__(message)
+        self.message = message
+        self.error_type = error_type
+        self.phase = phase
+
+
+class OutputCapture:
+    """Capture both Python-level and file-descriptor-level stdout/stderr.
+
+    This context manager redirects:
+      - Python ``sys.stdout`` / ``sys.stderr``
+      - OS file descriptors 1 and 2
+
+    into temporary files so that normal prints, Rich console output, and many
+    subprocess writes inherited from this process can be captured safely.
+
+    After the context exits, the original stdout/stderr streams and file
+    descriptors are restored, even if an exception occurs.
+    """
+
+    def __init__(self):
+        """Initialize the output capture state."""
+        self.stdout = ""
+        self.stderr = ""
+
+        self._stdout_tmp = None
+        self._stderr_tmp = None
+
+        self._old_stdout = None
+        self._old_stderr = None
+
+        self._old_stdout_fd = None
+        self._old_stderr_fd = None
+
+        self._capture_stdout = None
+        self._capture_stderr = None
+
+    def __enter__(self):
+        """Enter the capture context.
+
+        Returns:
+            OutputCapture: This output capture instance.
+        """
+        self._old_stdout = sys.stdout
+        self._old_stderr = sys.stderr
+
+        self._old_stdout_fd = os.dup(1)
+        self._old_stderr_fd = os.dup(2)
+
+        self._stdout_tmp = tempfile.TemporaryFile(mode="w+b")
+        self._stderr_tmp = tempfile.TemporaryFile(mode="w+b")
+
+        os.dup2(self._stdout_tmp.fileno(), 1)
+        os.dup2(self._stderr_tmp.fileno(), 2)
+
+        self._capture_stdout = os.fdopen(os.dup(1), "w", encoding="utf-8", buffering=1)
+        self._capture_stderr = os.fdopen(os.dup(2), "w", encoding="utf-8", buffering=1)
+
+        sys.stdout = self._capture_stdout
+        sys.stderr = self._capture_stderr
+
+        return self
+
+    def __exit__(self, exc_type, exc, exc_tb):
+        """Exit the capture context and restore stdout/stderr.
+
+        Args:
+            exc_type (type | None): Exception type if an exception occurred.
+            exc (BaseException | None): Exception instance if an exception occurred.
+            exc_tb (types.TracebackType | None): Traceback if an exception occurred.
+
+        Returns:
+            bool: Always returns ``False`` so exceptions propagate normally.
+        """
+        try:
+            try:
+                if sys.stdout is not None:
+                    sys.stdout.flush()
+            except (OSError, ValueError):
+                pass
+
+            try:
+                if sys.stderr is not None:
+                    sys.stderr.flush()
+            except (OSError, ValueError):
+                pass
+
+            try:
+                if self._stdout_tmp is not None:
+                    self._stdout_tmp.flush()
+            except OSError:
+                pass
+
+            try:
+                if self._stderr_tmp is not None:
+                    self._stderr_tmp.flush()
+            except OSError:
+                pass
+
+            try:
+                if self._stdout_tmp is not None:
+                    self._stdout_tmp.seek(0)
+                    self.stdout = self._stdout_tmp.read().decode("utf-8", errors="replace")
+            except OSError:
+                self.stdout = ""
+
+            try:
+                if self._stderr_tmp is not None:
+                    self._stderr_tmp.seek(0)
+                    self.stderr = self._stderr_tmp.read().decode("utf-8", errors="replace")
+            except OSError:
+                self.stderr = ""
+
+        finally:
+            try:
+                if self._capture_stdout is not None:
+                    self._capture_stdout.close()
+            except OSError:
+                pass
+
+            try:
+                if self._capture_stderr is not None:
+                    self._capture_stderr.close()
+            except OSError:
+                pass
+
+            if self._old_stdout_fd is not None:
+                os.dup2(self._old_stdout_fd, 1)
+                os.close(self._old_stdout_fd)
+
+            if self._old_stderr_fd is not None:
+                os.dup2(self._old_stderr_fd, 2)
+                os.close(self._old_stderr_fd)
+
+            sys.stdout = self._old_stdout
+            sys.stderr = self._old_stderr
+
+            try:
+                if self._stdout_tmp is not None:
+                    self._stdout_tmp.close()
+            except OSError:
+                pass
+
+            try:
+                if self._stderr_tmp is not None:
+                    self._stderr_tmp.close()
+            except OSError:
+                pass
+
+        return False
+
+
+def run_phase_with_capture(func, *args, **kwargs):
+    """Execute a function while capturing stdout and stderr.
+
+    Args:
+        func (callable): Function to execute.
+        *args: Positional arguments for ``func``.
+        **kwargs: Keyword arguments for ``func``.
+
+    Returns:
+        tuple: A tuple containing:
+            - result (Any): The return value of ``func``.
+            - stdout_text (str): Captured stdout text.
+            - stderr_text (str): Captured stderr text.
+    """
+    with OutputCapture() as capture:
+        result = func(*args, **kwargs)
+    return result, capture.stdout, capture.stderr
+
+
+def get_mc_list(cli_args, install_mcs=None):
+    """Get the list of model components and their arguments from the command line.
+
+    Args:
+        cli_args (list): List of command-line input model components.
+        install_mcs (bool | None): Whether to install model components automatically.
             By default, this method will defer to the default defined by the model component
             object's constructor. If set to :py:data:`False`, model components will not
             be installed.
 
     Returns:
         list: A list of model component objects.
+
+    Raises:
+        ExperimentHelperError: If a model component argument is malformed.
     """
     initial_mc_list = []
     for init_mc in cli_args:
@@ -144,8 +338,11 @@ def get_mc_list(cli_args, install_mcs=None):
             elif len(arg_sp) == 1:
                 anon_args.append(arg_sp[0])
             else:
-                print(f"ERROR: Malformed argument for ModelComponent {init_mc_name}.")
-                sys.exit(errno.EDEADLK)
+                raise ExperimentHelperError(
+                    f"Malformed argument for ModelComponent {init_mc_name}.",
+                    "malformed_model_component_argument",
+                    "model_component_resolution",
+                )
         if len(anon_args) > 0:
             args["plugin"][""] = anon_args
 
@@ -155,15 +352,20 @@ def get_mc_list(cli_args, install_mcs=None):
 
 
 def create_cli_parser():
-    """
-    Create an :py:class:`argparse.ArgumentParser` for the ``experiment`` Helper.
+    """Create an argparse parser for the experiment helper.
 
     Returns:
-        argparse.ArgumentParser: The ``experiment`` Helper parser.
+        argparse.ArgumentParser: The configured parser.
     """
     parser = argparse.ArgumentParser(
         description="Start a FIREWHEEL experiment.",
         prog="firewheel experiment",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format. Defaults to table.",
     )
     parser.add_argument(
         "--profile",
@@ -235,20 +437,22 @@ def create_cli_parser():
     return parser
 
 
-def print_output(console, dependency_time=0.0, total_time=0.0, exp_result=None):
-    """
-    Print the output from this Helper in an easy-to-read format.
+def build_table_result(dependency_graph_time=0.0, total_time=0.0, exp_result=None):
+    """Build a Rich table for experiment execution results.
 
     Args:
-        console (rich.console.Console): The console for displaying output.
-        dependency_time (float): The time it took to generate the dependency graph.
-        total_time (float): The total time for this Helper to run.
-        exp_result (list): A list of results from the execution of each MC.
+        dependency_graph_time (float): Time to generate the dependency graph.
+        total_time (float): Total helper runtime.
+        exp_result (list | None): Results from each MC execution.
 
     Returns:
-        int: An exit code indicating how many MC failed, or zero if all succeeded.
+        tuple: A tuple containing:
+            - table (RichDefaultTable): The rendered results table.
+            - exit_code (int): Exit code based on model component failures.
     """
-    caption = f"Dependency resolution took [cyan]{dependency_time:.3f}[/ cyan] seconds"
+    caption = (
+        f"Dependency graph resolution took [cyan]{dependency_graph_time:.3f}[/ cyan] seconds"
+    )
 
     table = RichDefaultTable(
         title="Model Components Executed",
@@ -280,36 +484,145 @@ def print_output(console, dependency_time=0.0, total_time=0.0, exp_result=None):
             f"[cyan]{res['time']:.3f}[/] seconds",
         )
 
+    return table, exit_code
+
+
+def render_table(console, dependency_graph_time=0.0, total_time=0.0, exp_result=None):
+    """Print table output for human-readable mode.
+
+    Args:
+        console (rich.console.Console): Console for rendering.
+        dependency_graph_time (float): Dependency graph resolution time.
+        total_time (float): Total helper runtime.
+        exp_result (list | None): Experiment execution results.
+
+    Returns:
+        int: Exit code.
+    """
+    table, exit_code = build_table_result(
+        dependency_graph_time, total_time, exp_result
+    )
     console.print("\n", table, "\n")
     return exit_code
 
 
-def run_experiment(mcm, console, dry_run=False, is_profile=False):
-    """
-    Execute all model components which have been included within the dependency graph.
+def build_json_success_result(
+    cmd_args,
+    active_exp_present,
+    dependency_graph_time,
+    total_time,
+    exp_result,
+    captured_output,
+):
+    """Build the final JSON success payload.
 
     Args:
-        mcm (firewheel.control.model_component_manager.ModelComponentManager): The
-            ModelComponentManager used to execute the experiment graph.
-        console (rich.console.Console): The console for displaying output.
-        dry_run (bool): If this is a dry run. Defaults to False.
-        is_profile (bool): If the execution should be profiled. Defaults to False.
+        cmd_args (argparse.Namespace): Parsed command-line arguments.
+        active_exp_present (bool): Whether an active experiment was detected.
+        dependency_graph_time (float): Time to build the dependency graph.
+        total_time (float): Total helper runtime.
+        exp_result (list): Results from experiment execution.
+        captured_output (dict): Captured stdout/stderr grouped by phase.
 
     Returns:
-        list: A list of the experimental results.
+        dict: Structured JSON success payload.
+    """
+    exit_code = sum(1 for res in exp_result if res["errors"])
+
+    return {
+        "success": exit_code == 0,
+        "dry_run": cmd_args.dry_run,
+        "profile_enabled": cmd_args.profile,
+        "force": cmd_args.force,
+        "restart": cmd_args.restart,
+        "no_install": cmd_args.no_install,
+        "active_experiment_detected": active_exp_present,
+        "dependency_graph_time": dependency_graph_time,
+        "total_time": total_time,
+        "model_components": [
+            {
+                "name": res["model_component"],
+                "success": not res["errors"],
+                "errors": res["errors"],
+                "time": res["time"],
+            }
+            for res in exp_result
+        ],
+        "captured_output": captured_output,
+        "message": (
+            "Experiment completed successfully."
+            if exit_code == 0
+            else "Experiment completed with model component failures."
+        ),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def build_json_error_result(
+    cmd_args,
+    active_exp_present,
+    error,
+    captured_output,
+    dependency_graph_time=None,
+    total_time=None,
+):
+    """Build the final JSON error payload.
+
+    Args:
+        cmd_args (argparse.Namespace): Parsed command-line arguments.
+        active_exp_present (bool): Whether an active experiment was detected.
+        error (ExperimentHelperError): Structured helper error.
+        captured_output (dict): Captured stdout/stderr grouped by phase.
+        dependency_graph_time (float | None): Time to build dependency graph, if known.
+        total_time (float | None): Total helper runtime, if known.
+
+    Returns:
+        dict: Structured JSON error payload.
+    """
+    return {
+        "success": False,
+        "dry_run": cmd_args.dry_run,
+        "profile_enabled": cmd_args.profile,
+        "force": cmd_args.force,
+        "restart": cmd_args.restart,
+        "no_install": cmd_args.no_install,
+        "active_experiment_detected": active_exp_present,
+        "dependency_graph_time": dependency_graph_time,
+        "total_time": total_time,
+        "phase": error.phase,
+        "error": {
+            "type": error.error_type,
+            "detail": error.message,
+        },
+        "captured_output": captured_output,
+        "message": error.message,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def run_experiment(mcm, console, dry_run=False, is_profile=False):
+    """Execute all model components included within the dependency graph.
+
+    Args:
+        mcm (ModelComponentManager): The manager used to execute the graph.
+        console (rich.console.Console): Console for displaying output.
+        dry_run (bool): Whether this is a dry run.
+        is_profile (bool): Whether execution should be profiled.
+
+    Returns:
+        list: Experimental results.
+
+    Raises:
+        ExperimentHelperError: If plugin arguments are invalid.
     """
     exp_result = []
     try:
-        # Check if the experiment should be profiled
         if is_profile:
             profile = cProfile.Profile()
             profile.enable()
 
-        # Build the experiment graph and execute model components
-        # per the dependency graph
         exp_result = mcm.build_experiment_graph(dry_run=dry_run)
 
-        # Stop the profiler (if any)
         if is_profile:
             profile.disable()
             profile.dump_stats("firewheel_profile.prof")
@@ -325,72 +638,238 @@ def run_experiment(mcm, console, dry_run=False, is_profile=False):
             "\n[error]ERROR:[/error] Invalid arguments to experiment graph plugin."
         )
         console.print(f"\nDetails: {exc_str}")
-        sys.exit(errno.EINVAL)
+        raise ExperimentHelperError(
+            "Invalid arguments to experiment graph plugin.",
+            "invalid_plugin_arguments",
+            "execution",
+        ) from None
+
     return exp_result
 
 
-def main():
+def determine_active_experiment(cmd_args):
+    """Determine whether an active experiment is present.
+
+    Args:
+        cmd_args (argparse.Namespace): Parsed arguments.
+
+    Returns:
+        bool: Whether an active experiment is present.
     """
-    Execute the main logic of this Helper.
-    """
-
-    console = Console(theme=cli_output_theme)
-
-    # Get the start time
-    total_start = datetime.now()
-
-    # Create the argparse parser and get CLI input
-    parser = create_cli_parser()
-    cmd_args = parser.parse_args()
-
-    # Execute various CLI options
     active_exp_present = False
     if cmd_args.restart:
         mm_api = minimegaAPI()
         if vrm_api.get_experiment_launch_time() is not None or mm_api.mm_vms():
             active_exp_present = True
+    return active_exp_present
 
+
+def maybe_restart_environment(cmd_args, console, active_exp_present):
+    """Restart the environment if requested.
+
+    Args:
+        cmd_args (argparse.Namespace): Parsed arguments.
+        console (rich.console.Console): Console for text output.
+        active_exp_present (bool): Whether an active experiment is present.
+
+    Raises:
+        ExperimentHelperError: If environment restart fails.
+    """
     if cmd_args.force is True or (cmd_args.restart and active_exp_present is True):
-        console.print("Cleaning up any running experiments.")
-        FirewheelCLI().onecmd("restart")
-        console.print("All running experiments have been cleared.")
+        try:
+            console.print("Cleaning up any running experiments.")
+            FirewheelCLI().onecmd("restart")
+            console.print("All running experiments have been cleared.")
+        except OSError as exc:
+            raise ExperimentHelperError(
+                f"Failed to restart the environment: {exc}",
+                "environment_restart_failed",
+                "environment_prepare",
+            ) from exc
 
-    # Get the MC names passed in via command line
-    initial_mc_list = get_mc_list(cmd_args.model_component, install_mcs=cmd_args.no_install)
 
-    # Build the model component dependency graph
-    ds = datetime.now()
-    mcm = ModelComponentManager(console=console)
-    try:
-        mcm.build_dependency_graph(initial_mc_list, install_mcs=cmd_args.no_install)
-    except UnsatisfiableDependenciesError:
-        exc_type, exc_value, exc_traceback = sys.exc_info()
-        exc_str = "".join(
-            traceback.format_exception(exc_type, exc_value, exc_traceback)
+def initialize_captured_output():
+    """Initialize the phase-based captured output structure.
+
+    Returns:
+        dict: Empty stdout/stderr buckets for each phase.
+    """
+    return {
+        "environment_prepare": {"stdout": "", "stderr": ""},
+        "model_component_resolution": {"stdout": "", "stderr": ""},
+        "dependency_graph": {"stdout": "", "stderr": ""},
+        "execution": {"stdout": "", "stderr": ""},
+    }
+
+
+def append_phase_capture(captured_output, phase, stdout_text, stderr_text):
+    """Append captured output for a phase.
+
+    Args:
+        captured_output (dict): The aggregate captured output structure.
+        phase (str): Phase name.
+        stdout_text (str): Captured stdout text.
+        stderr_text (str): Captured stderr text.
+    """
+    captured_output[phase]["stdout"] += stdout_text
+    captured_output[phase]["stderr"] += stderr_text
+
+
+def main():
+    """Execute the main logic of the experiment helper."""
+    console = Console(theme=cli_output_theme)
+
+    total_start = datetime.now()
+    parser = create_cli_parser()
+    cmd_args = parser.parse_args()
+
+    json_mode = cmd_args.format == "json"
+
+    if json_mode and cmd_args.no_install is not False:
+        error = ExperimentHelperError(
+            "JSON output requires non-interactive execution. Re-run with --no-install.",
+            "interactive_install_possible",
+            "argument_validation",
         )
-        console.print(
-            "[error]ERROR:[/error] Unable to build model component dependency graph due to the "
-            f"following error:\n\n{exc_str}\n\nNo Model Components were evaluated and no restart is "
-            "required. "
+        result = build_json_error_result(
+            cmd_args=cmd_args,
+            active_exp_present=False,
+            error=error,
+            captured_output={},
         )
+        print(json.dumps(result, indent=2))
         sys.exit(1)
 
-    # Calculate the time it takes to generate the dependency graph
-    de = datetime.now()
-    dependency_time = (de - ds).total_seconds()
+    captured_output = initialize_captured_output()
 
-    # Execute the Model Components (i.e. run the experiment)
-    exp_result = run_experiment(mcm, console, cmd_args.dry_run, cmd_args.profile)
+    active_exp_present = False
+    dependency_graph_time = None
 
-    # Get the total experiment time
-    total_end = datetime.now()
-    total_time = (total_end - total_start).total_seconds()
+    try:
+        active_exp_present = determine_active_experiment(cmd_args)
 
-    # Print output for the user
-    exit_code = print_output(console, dependency_time, total_time, exp_result)
+        if json_mode:
+            _, stdout_text, stderr_text = run_phase_with_capture(
+                maybe_restart_environment,
+                cmd_args,
+                console,
+                active_exp_present,
+            )
+            append_phase_capture(
+                captured_output, "environment_prepare", stdout_text, stderr_text
+            )
+        else:
+            maybe_restart_environment(cmd_args, console, active_exp_present)
 
-    # Exit with the provided exit code
-    sys.exit(exit_code)
+        if json_mode:
+            initial_mc_list, stdout_text, stderr_text = run_phase_with_capture(
+                get_mc_list,
+                cmd_args.model_component,
+                install_mcs=cmd_args.no_install,
+            )
+            append_phase_capture(
+                captured_output, "model_component_resolution", stdout_text, stderr_text
+            )
+        else:
+            initial_mc_list = get_mc_list(
+                cmd_args.model_component,
+                install_mcs=cmd_args.no_install,
+            )
+
+        ds = datetime.now()
+        mcm = ModelComponentManager(console=console)
+
+        try:
+            if json_mode:
+                _, stdout_text, stderr_text = run_phase_with_capture(
+                    mcm.build_dependency_graph,
+                    initial_mc_list,
+                    install_mcs=cmd_args.no_install,
+                )
+                append_phase_capture(
+                    captured_output, "dependency_graph", stdout_text, stderr_text
+                )
+            else:
+                mcm.build_dependency_graph(
+                    initial_mc_list,
+                    install_mcs=cmd_args.no_install,
+                )
+        except UnsatisfiableDependenciesError:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            exc_str = "".join(
+                traceback.format_exception(exc_type, exc_value, exc_traceback)
+            )
+            if json_mode:
+                raise ExperimentHelperError(
+                    exc_str,
+                    "unsatisfiable_dependencies",
+                    "dependency_graph",
+                ) from None
+
+            console.print(
+                "[error]ERROR:[/error] Unable to build model component dependency graph due to the "
+                f"following error:\n\n{exc_str}\n\nNo Model Components were evaluated and no restart is "
+                "required. "
+            )
+            sys.exit(1)
+
+        de = datetime.now()
+        dependency_graph_time = (de - ds).total_seconds()
+
+        if json_mode:
+            exp_result, stdout_text, stderr_text = run_phase_with_capture(
+                run_experiment,
+                mcm,
+                console,
+                cmd_args.dry_run,
+                cmd_args.profile,
+            )
+            append_phase_capture(captured_output, "execution", stdout_text, stderr_text)
+        else:
+            exp_result = run_experiment(mcm, console, cmd_args.dry_run, cmd_args.profile)
+
+        total_end = datetime.now()
+        total_time = (total_end - total_start).total_seconds()
+
+        if json_mode:
+            result = build_json_success_result(
+                cmd_args=cmd_args,
+                active_exp_present=active_exp_present,
+                dependency_graph_time=dependency_graph_time,
+                total_time=total_time,
+                exp_result=exp_result,
+                captured_output=captured_output,
+            )
+            print(json.dumps(result, indent=2))
+            exit_code = sum(1 for res in exp_result if res["errors"])
+            sys.exit(exit_code)
+
+        exit_code = render_table(
+            console,
+            dependency_graph_time,
+            total_time,
+            exp_result,
+        )
+        sys.exit(exit_code)
+
+    except ExperimentHelperError as exc:
+        total_end = datetime.now()
+        total_time = (total_end - total_start).total_seconds()
+
+        if json_mode:
+            result = build_json_error_result(
+                cmd_args=cmd_args,
+                active_exp_present=active_exp_present,
+                error=exc,
+                captured_output=captured_output,
+                dependency_graph_time=dependency_graph_time,
+                total_time=total_time,
+            )
+            print(json.dumps(result, indent=2))
+            sys.exit(1)
+
+        console.print(f"[error]ERROR:[/error] {exc.message}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/firewheel/cli/helpers/experiment
+++ b/src/firewheel/cli/helpers/experiment
@@ -5,7 +5,7 @@ DESCRIPTION
 
 Create a FIREWHEEL experiment using a set of model components.
 
-**Usage:**  ``firewheel experiment [-h] [--profile] [--dry-run] [-f] <model_component>[:<name1>=<value1>[:<name2>=<value2>]...] [<model_component2>[:<name1>=<value1>[:<name2>=<value2>]...]]``
+**Usage:**  ``firewheel experiment [-h] [--format {table,json}] [--profile] [--dry-run] [-f] [-r] [-ni] <model_component>[:<name1>=<value1>[:<name2>=<value2>]...] [<model_component2>[:<name1>=<value1>[:<name2>=<value2>]...]]``
 
 All of the experiment Helper's command line arguments, along with any named
 MC parameter value settings, must be included on a single line.
@@ -28,6 +28,15 @@ Component) or realizing the topology into an emulation. The current method to
 launch an experiment is to use the ``minimega.launch`` model component which uses
 `minimega <https://www.sandia.gov/minimega>`_ to instantiate the emulation. **NOTE: This is not required**.
 FIREWHEEL is extensible and enables users to create other experiment instantiation methods.
+
+This Helper supports both human-readable table output and machine-readable
+JSON output.
+
+.. note::
+
+    When using ``--format json``, this Helper requires non-interactive execution.
+    Re-run with :option:`--no-install` to prevent interactive Model Component
+    INSTALL prompting.
 
 Arguments
 +++++++++
@@ -54,13 +63,19 @@ Positional Arguments
         $ # Muliple MC named arguments
         $ firewheel experiment tests.router_tree:3 tests.large_resource:size=1024:location_dir=/tmp:preload=True minimega.launch
 
-
 Named Arguments
 ^^^^^^^^^^^^^^^
 
 .. option:: -h, --help
 
     Print this experiment Helper description then exit. (optional)
+
+.. option:: --format {table,json}
+
+    :default: ``table``
+
+    Select the output format. ``table`` prints a human-readable execution summary.
+    ``json`` returns a structured JSON response.
 
 .. option:: -f, --force
 
@@ -82,7 +97,6 @@ Named Arguments
 
     Continue regardless of if Model Components within the experiment have been "installed" (i.e., the ``INSTALL`` file executed). Defaults to None. (optional)
 
-
 Examples
 ++++++++
 ``firewheel experiment acme.run minimega.launch``
@@ -92,6 +106,8 @@ Examples
 ``firewheel experiment tests.vm_gen:size=3 minimega.launch``
 
 ``firewheel experiment -r tests.vm_gen:size=3 tests.connect_all tests.ping_all minimega.launch``
+
+``firewheel experiment --format json --no-install tests.router_tree:3 minimega.launch``
 
 DONE
 RUN LocalPython ON control

--- a/src/firewheel/cli/helpers/mc/list
+++ b/src/firewheel/cli/helpers/mc/list
@@ -67,7 +67,6 @@ Named Arguments
     ``attributes``                 The dictionary of both provides and depends. Filters provided return true if found in either provides or depends.
     ``model_component_depends``    The model components depended on by the MC.
     ``model_component_precedes``   The model components preceded by the MC.
-    ``model_component_objects``    The model component objects provided by the MC.
     ``vm_resources``               The VM Resources provided by the MC. This will not auto-expand any wildcards (e.g. ``vm_resources/**``).
     ============================   ==================================================================================================================================
 
@@ -170,6 +169,8 @@ def parse_field_filters(args_fields):
 
 def check_field_filter(field_filter, elem):
     """Check if an element matches the specified field filter.
+
+    It checks both top-level keys and nested attributes within the element.
 
     Args:
         field_filter (dict): Field filter criteria.

--- a/src/firewheel/cli/helpers/mc/list
+++ b/src/firewheel/cli/helpers/mc/list
@@ -4,12 +4,16 @@ DONE
 DESCRIPTION
 
 List information about the currently installed model components.
-Model components can be grouped by repository (default), or any of the ``provides``, ``depends``, ``precedes``, ``model_component_depends``, ``model_component_precedes``.
-fields in the model component's manifest.
-Filters can be used to reduce the MCs that are shown. Filters are independent and
-are greedily matching. If multiple filters are used then anything that matches **all**
-filters will be displayed. Filters will attempt substring matching so ensure that
-you provide enough of a substring to the filter to narrow down the displayed results.
+Model components can be grouped by repository (default), or any of the
+``provides``, ``depends``, ``precedes``, ``model_component_depends``, or
+``model_component_precedes`` fields in the model component's manifest.
+
+Filters can be used to reduce the Model Components that are shown. Filters are
+independent and are greedily matching. If multiple filters are used then anything
+that matches **all** filters will be displayed. Filters attempt substring matching,
+so ensure that you provide enough of a substring to narrow down the displayed results.
+
+This Helper supports both human-readable text output and machine-readable JSON output.
 
 Arguments
 +++++++++
@@ -23,24 +27,33 @@ Named Arguments
 
     Show a help message and exit.
 
+.. option:: --format {text,json}
+
+    :default: ``text``
+
+    Select the output format. ``text`` prints a grouped human-readable listing.
+    ``json`` returns a structured JSON response.
+
 .. option:: --paths, -p
 
-    Print additional paths information.
+    Print additional path information.
 
 .. option:: -g <group>, --group <group>
 
     :default: ``repository``
 
-    Group model components by one of: ``repository``, ``provides``, ``depends``, ``model_component_depends``.
-
-.. option:: -m
-
-    Print without color, i.e. monochromatic.
+    Group model components by one of:
+    ``repository``, ``provides``, ``depends``, ``precedes``,
+    ``model_component_depends``, or ``model_component_precedes``.
 
 .. option:: -k <FIELDS [FIELDS ...]>
 
-    Space separated list of additional MANIFEST fields to display for each found MC, in the form field[=filter] where filter is an optional substring of the results being filtered on.
-    Example fields are in the following table, but any manifest fields should be valid.
+    Space separated list of additional MANIFEST fields to display for each found MC,
+    in the form field[=filter] where filter is an optional substring of the results
+    being filtered on.
+
+    Example fields are shown in the following table, but any manifest fields
+    should be valid.
 
     .. tabularcolumns:: |\Y{.32}|\Y{.68}|
 
@@ -54,91 +67,156 @@ Named Arguments
     ``attributes``                 The dictionary of both provides and depends. Filters provided return true if found in either provides or depends.
     ``model_component_depends``    The model components depended on by the MC.
     ``model_component_precedes``   The model components preceded by the MC.
-    ``model_component_objects``    The model_component_objects provided by the MC.
-    ``vm_resources``               The VM Resources proved by the MC. This will not auto-expand any wildcards (e.g. ``vm_resources/**``).
+    ``model_component_objects``    The model component objects provided by the MC.
+    ``vm_resources``               The VM Resources provided by the MC. This will not auto-expand any wildcards (e.g. ``vm_resources/**``).
     ============================   ==================================================================================================================================
-
 
 Examples
 ++++++++
+``firewheel mc list``
 
 ``firewheel mc list -p``
 
-``firewheel mc list -p -m -k provides=topology``
+``firewheel mc list -k provides=topology``
 
 ``firewheel mc list -p -g provides -k name=ubuntu``
 
 ``firewheel mc list -k vm_resources``
 
-
+``firewheel mc list --format json -g repository -k provides=topology``
 
 DONE
 RUN LocalPython ON control
 #!/usr/bin/env python
 
 import sys
+import json
 import argparse
 from collections import OrderedDict
+from datetime import datetime, timezone
 
-import colorama
+from rich.console import Console
 
 from firewheel.control.repository_db import RepositoryDb
 from firewheel.control.model_component_iterator import ModelComponentIterator
 
 
+class McListError(Exception):
+    """Expected operational error for the mc list helper.
+
+    Args:
+        message (str): Human-readable error message.
+        error_type (str): Stable machine-readable error type.
+    """
+
+    def __init__(self, message, error_type):
+        """Initialize the exception.
+
+        Args:
+            message (str): Human-readable error message.
+            error_type (str): Stable machine-readable error type.
+        """
+        super().__init__(message)
+        self.message = message
+        self.error_type = error_type
+
+
+def build_error_result(message, error_type):
+    """Build a structured error result.
+
+    Args:
+        message (str): Human-readable error message.
+        error_type (str): Stable machine-readable error type.
+
+    Returns:
+        dict: Structured error result.
+    """
+    return {
+        "success": False,
+        "error": {
+            "type": error_type,
+            "detail": message,
+        },
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def parse_field_filters(args_fields):
+    """Parse requested fields and filters.
+
+    Args:
+        args_fields (list[str] | None): CLI field filter arguments.
+
+    Returns:
+        collections.OrderedDict: Ordered field filter mapping.
+    """
+    filters = OrderedDict()
+
+    if args_fields:
+        for argfield in args_fields:
+            field_vals = argfield.split("=")
+            field_name = field_vals[0]
+
+            if field_name in {"depends", "provides"} and "attributes" not in filters:
+                filters["attributes"] = None
+
+            if len(field_vals) > 1:
+                filters[field_name] = field_vals[1]
+            elif field_name not in filters:
+                filters[field_name] = None
+
+    return filters
+
+
 def check_field_filter(field_filter, elem):
     """Check if an element matches the specified field filter.
 
-    This function evaluates whether the given element meets the criteria
-    defined in the field filter. It checks both top-level keys and nested
-    attributes within the element.
-
     Args:
-        field_filter (dict): A dictionary containing the filter criteria
-            for the fields.
-        elem (dict): The element to be checked against the filter.
+        field_filter (dict): Field filter criteria.
+        elem (dict): Candidate element to check.
 
     Returns:
-        bool: True if the element matches the filter criteria, False otherwise.
+        bool: True if the element matches the filter, otherwise False.
     """
-    for k, v in elem.items():
-        if k == "attributes":
-            if field_filter[k] and field_filter[k] not in str(v):
+    for key, value in elem.items():
+        if key == "attributes":
+            if field_filter.get(key) and field_filter[key] not in str(value):
                 return False
-            for k2, v2 in v.items():
-                if (filter_k2 := field_filter.get(k2)) and filter_k2 not in "".join(v2):
+            for key2, value2 in value.items():
+                filter_value = field_filter.get(key2)
+                if filter_value and filter_value not in "".join(value2):
                     return False
-        elif k in field_filter and field_filter[k] and field_filter[k] not in v:
+        elif key in field_filter and field_filter[key] and field_filter[key] not in str(value):
             return False
     return True
 
 
-def group_by_key(group_key, paths=False, field_filter=None, fields=None):
-    """Group model components by a specified key.
-
-    This function iterates through a list of repositories and groups model
-    components based on the specified grouping key. It applies a field filter
-    to determine which elements to include in the grouping.
+def collect_grouped_model_components(repo_list, group_key, paths=False, field_filter=None, fields=None):
+    """Collect grouped model component data.
 
     Args:
-        group_key (str): The key by which to group the model components.
-            Possible values include "repository", "depends", "provides",
-            "precedes", "model_component_depends", and "model_component_precedes".
-        paths (bool, optional): If :py:data:`True`, include paths in the output.
-            Defaults to :py:data:`False`.
-        field_filter (dict, optional): A dictionary of field filters to apply
-            to the elements. Defaults to :py:data:`None`.
-        fields (list, optional): A list of fields to include in the output.
-            Defaults to :py:data:`None`.
+        repo_list (list[dict]): Installed repositories.
+        group_key (str): Grouping key.
+        paths (bool): Whether paths were requested.
+        field_filter (dict | None): Field filters to apply.
+        fields (list[str] | None): Requested fields to include.
+
+    Returns:
+        dict: Structured grouped MC data.
+
+    Raises:
+        McListError: If no matching model components are found.
     """
     group_key_dict = {}
-    max_elem_name_len = 0
+    total_count = 0
+
     for repo in repo_list:
         model_component_iter = ModelComponentIterator(iter([repo]))
         for mc_src in model_component_iter:
             elems = []
+
             if group_key == "repository":
-                group_val = repo
+                group_val = repo["path"]
                 elem = {
                     "repository": repo["path"],
                     "name": mc_src.name,
@@ -148,8 +226,10 @@ def group_by_key(group_key, paths=False, field_filter=None, fields=None):
                     for field in fields:
                         if field in mc_src.manifest:
                             elem[field] = mc_src.manifest[field]
+
                 if not check_field_filter(field_filter, elem):
                     continue
+
                 elems.append(elem)
 
             elif group_key in {
@@ -160,14 +240,13 @@ def group_by_key(group_key, paths=False, field_filter=None, fields=None):
                 "model_component_precedes",
             }:
                 if group_key in {"depends", "provides", "precedes"}:
-                    attribute_index = ["depends", "provides", "precedes"].index(
-                        group_key
-                    )
+                    attribute_index = ["depends", "provides", "precedes"].index(group_key)
                     group_vals = mc_src.get_attributes()[attribute_index]
                 elif group_key == "model_component_precedes":
                     group_vals = mc_src.get_model_component_precedes()
                 else:
                     group_vals = mc_src.get_model_component_depends()
+
                 for group_val in group_vals:
                     elem = {
                         group_key: group_val,
@@ -175,87 +254,113 @@ def group_by_key(group_key, paths=False, field_filter=None, fields=None):
                         "name": mc_src.name,
                         "path": mc_src.path,
                     }
+                    if fields:
+                        for field in fields:
+                            if field in mc_src.manifest and field not in elem:
+                                elem[field] = mc_src.manifest[field]
                     elems.append(elem)
+
             for elem in elems:
                 group_val = elem[group_key]
 
                 if not check_field_filter(field_filter, elem):
                     continue
 
-                max_elem_name_len = max(max_elem_name_len, len(elem["name"]))
                 if group_val not in group_key_dict:
-                    group_key_dict[group_val] = [elem]
-                else:
-                    group_key_dict[group_val].append(elem)
-    if max_elem_name_len == 0:
-        # No matching elements were found.
-        print("No model components found!")
-        sys.exit(1)
-    else:
-        print_output(group_key, group_key_dict, max_elem_name_len, paths, fields)
+                    group_key_dict[group_val] = []
+                group_key_dict[group_val].append(elem)
+                total_count += 1
+
+    if total_count == 0:
+        raise McListError("No model components found!", "no_model_components_found")
+
+    groups = []
+    for group_val in sorted(group_key_dict):
+        groups.append(
+            {
+                "group": group_val,
+                "items": group_key_dict[group_val],
+            }
+        )
+
+    return {
+        "success": True,
+        "group_by": group_key,
+        "paths": paths,
+        "fields": fields or [],
+        "filters": dict(field_filter or {}),
+        "count": total_count,
+        "groups": groups,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
 
 
-def print_output(
-    group_key, group_key_dict, max_elem_name_len, paths=False, fields=None,
-):
-    """Print the grouped output of model components.
-
-    This function formats and prints the grouped model components based on
-    the specified grouping key and selected fields. It handles both
-    repository and other grouping keys, providing options for including
-    paths in the output.
+def render_text(mc_data):
+    """Render grouped model component output in text form using Rich.
 
     Args:
-        group_key (str): The key by which the model components are grouped.
-        group_key_dict (dict): A dictionary containing the grouped model components.
-        max_elem_name_len (int): The maximum length of element names for formatting purposes.
-        paths (bool, optional): If :py:data:`True`, include paths in the output.
-            Defaults to :py:data:`False`.
-        fields (list, optional): A list of fields to include in the output.
-            Defaults to :py:data:`None`.
+        mc_data (dict): Structured grouped MC data.
     """
+    console = Console()
+
+    group_key = mc_data["group_by"]
+    fields = mc_data["fields"]
+    paths = mc_data["paths"]
+
     if group_key == "repository":
-        print_keys = [i for i in fields if i not in {"repository", "name"}]
+        print_keys = [field for field in fields if field not in {"repository", "name"}]
     else:
-        print_keys = [i for i in fields if i not in {group_key}]
+        print_keys = [field for field in fields if field != group_key]
+
     if paths and "path" in print_keys:
         print_keys.remove("path")
-    for group_val in sorted(group_key_dict):
-        style_index = 0
-        print(f"{BRIGHT}{YELLOW}{group_key} : {group_val}{RESET_ALL}")
-        for elem in group_key_dict[group_val]:
-            style_index = (style_index + 1) % len(colors)
+
+    for group in mc_data["groups"]:
+        console.print(f"[bold yellow]{group_key} : {group['group']}[/bold yellow]")
+
+        for item in group["items"]:
             if print_keys and group_key == "repository":
-                print(f"  {LIGHTBLUE_EX + BRIGHT}{elem['name']}")
-                print(RESET_ALL, end="")
+                console.print(f"  [bold bright_blue]{item['name']}[/bold bright_blue]")
+
                 if paths:
-                    print(f"    'path' : {elem['path']}")
+                    console.print(f"    path : {item['path']}")
 
                 for print_key in print_keys:
-                    if print_key in elem:
+                    if print_key in item:
                         if print_key == "attributes":
-                            print("    attributes:")
-                            attributes = elem[print_key]
-                            for k, v in attributes.items():
-                                print(f"      {k} : {v}")
+                            console.print("    attributes:")
+                            attributes = item[print_key]
+                            for attr_key, attr_value in attributes.items():
+                                console.print(f"      {attr_key} : {attr_value}")
                         else:
-                            print(f"    {print_key} : {elem[print_key]}")
+                            console.print(f"    {print_key} : {item[print_key]}")
             else:
-                print(RESET_ALL, end="")
-                if style_index % 2 == 0:
-                    print(LIGHTBLUE_EX + BRIGHT, end="")
                 if paths:
-                    # Left aligning the element name with some padding
-                    print(f"  {elem['name']:<{10 + max_elem_name_len}}\t{elem['path']}")
+                    console.print(f"  {item['name']}\t{item['path']}")
                 else:
-                    print(f"  {elem['name']:<{10 + max_elem_name_len}}")
-        print(RESET_ALL, end="")
+                    console.print(f"  {item['name']}")
 
 
-if __name__ == "__main__":
+def render_json(mc_data):
+    """Render grouped model component output as JSON.
+
+    Args:
+        mc_data (dict): Structured grouped MC data.
+    """
+    print(json.dumps(mc_data, indent=2))
+
+
+def main():
+    """Enumerate installed model components."""
     parser = argparse.ArgumentParser(
         description="Enumerate all installed model components!",
         prog="firewheel mc list",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format. Defaults to text.",
     )
     parser.add_argument(
         "--paths",
@@ -263,7 +368,7 @@ if __name__ == "__main__":
         required=False,
         action="store_true",
         dest="paths",
-        help="Print additional paths information.",
+        help="Print additional path information.",
         default=False,
     )
     parser.add_argument(
@@ -279,7 +384,7 @@ if __name__ == "__main__":
             "model_component_precedes",
         },
         dest="group",
-        help="Group model_components by.",
+        help="Group model components by.",
         default="repository",
     )
     parser.add_argument(
@@ -294,63 +399,49 @@ if __name__ == "__main__":
         default=None,
     )
 
-    parser.add_argument(
-        "-m",
-        required=False,
-        dest="monochromatic",
-        action="store_true",
-        help="Print without color",
-        default=False,
-    )
+    args = parser.parse_args()
 
     repo_db = RepositoryDb()
     repo_list = list(repo_db.list_repositories())
     if len(repo_list) == 0:
-        print(
-            (
-                "There are no model component repositories installed!\n"
-                "Install one with `firewheel repository install <path>`."
-            ),
-            file=sys.stderr,
+        error_message = (
+            "There are no model component repositories installed!\n"
+            "Install one with `firewheel repository install <path>`."
         )
+        if args.format == "json":
+            print(
+                json.dumps(
+                    build_error_result(error_message, "no_repositories_installed"),
+                    indent=2,
+                )
+            )
+        else:
+            print(error_message, file=sys.stderr)
         sys.exit(1)
 
-    TAB = "  "
-    args = parser.parse_args()
-    if not args.monochromatic:
-        RESET_ALL = colorama.Style.RESET_ALL
-        NORMAL = colorama.Style.NORMAL
-        BRIGHT = colorama.Style.BRIGHT
-        YELLOW = colorama.Fore.YELLOW
-        LIGHTBLUE_EX = colorama.Fore.LIGHTBLUE_EX
-        colors = [colorama.Fore.GREEN, colorama.Fore.BLUE]
-        styles = [colorama.Style.BRIGHT, colorama.Style.NORMAL]
-    else:
-        BRIGHT = ""
-        YELLOW = ""
-        RESET_ALL = ""
-        NORMAL = ""
-        LIGHTBLUE_EX = ""
-        colors = ["", ""]
-        styles = ["", ""]
+    filters = parse_field_filters(args.fields)
 
-    filters = OrderedDict()
-    if args.fields:
-        for argfield in args.fields:
-            field_vals = argfield.split("=")
-            field_name = field_vals[0]
-            if field_name in {"depends", "provides"}:
-                if "attributes" not in filters:
-                    filters["attributes"] = None
-            if len(field_vals) > 1:
-                filters[field_name] = field_vals[1]
-            elif field_name not in filters:
-                filters[field_name] = None
-    if args.group:
-        group_by_key(
-            args.group,
+    try:
+        mc_data = collect_grouped_model_components(
+            repo_list=repo_list,
+            group_key=args.group,
             paths=args.paths,
             field_filter=filters,
             fields=list(filters.keys()),
         )
+    except McListError as exc:
+        if args.format == "json":
+            print(json.dumps(build_error_result(exc.message, exc.error_type), indent=2))
+        else:
+            print(exc.message)
+        sys.exit(1)
+
+    if args.format == "json":
+        render_json(mc_data)
+    else:
+        render_text(mc_data)
+
+
+if __name__ == "__main__":
+    main()
 DONE

--- a/src/firewheel/cli/helpers/mm/show_caches
+++ b/src/firewheel/cli/helpers/mm/show_caches
@@ -2,15 +2,37 @@ AUTHOR
 FIREWHEEL Team
 DONE
 DESCRIPTION
-
-List the image and vm_resource cache directories which are found in the
+List the image and vm_resource cache directories found in the
 :class:`FileStore <firewheel.lib.minimega.file_store.FileStore>`. This enables
-users to identify if a file was correctly cached.
+users to identify whether a file was correctly cached.
+
+This Helper supports both human-readable table output and machine-readable
+JSON output.
+
+Arguments
++++++++++
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+.. option:: -h, --help
+
+    Show help message and exit.
+
+.. option:: --format {text,json}
+
+    :default: ``text``
+
+    Select the output format. ``text`` displays human-readable cache tables with
+    file sizes rendered in a human-friendly format. ``json`` returns a structured
+    JSON response with raw byte counts.
 
 Examples
 ++++++++
 
 ``firewheel mm show_caches``
+
+``firewheel mm show_caches --format json``
 
 DONE
 RUN LocalPython ON control

--- a/src/firewheel/cli/helpers/mm/show_caches
+++ b/src/firewheel/cli/helpers/mm/show_caches
@@ -106,8 +106,8 @@ def collect_cache_data():
 
     host = vm_resources_host or images_host or mm_api.get_head_node()
 
-    vm_resources_entries = normalize_cache_rows(vm_resources_rows)
-    images_entries = normalize_cache_rows(images_rows)
+    vm_resources_entries = sorted(normalize_cache_rows(vm_resources_rows), key=lambda r: r["name"])
+    images_entries = sorted(normalize_cache_rows(images_rows), key=lambda r: r["name"])
 
     return {
         "host": host,

--- a/src/firewheel/cli/helpers/mm/show_caches
+++ b/src/firewheel/cli/helpers/mm/show_caches
@@ -13,17 +13,206 @@ Examples
 ``firewheel mm show_caches``
 
 DONE
-RUN Shell ON control
-#!/bin/bash
-MM_INSTALL_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.install_dir)"
-MM_BASE_DIR="$("$FIREWHEEL_PYTHON" "$FIREWHEEL" config get minimega.base_dir)"
-MINIMEGA_BIN="$MM_INSTALL_DIR/bin/minimega -base=$MM_BASE_DIR"
+RUN LocalPython ON control
+#!/usr/bin/env python
 
-HOST=$(hostname)
-echo "Cache contents from $HOST:vm_resources"
-$MINIMEGA_BIN -e file list vm_resources
-echo
-echo "Cache contents from $HOST:images"
-$MINIMEGA_BIN -e file list images
-echo
+import json
+import argparse
+from datetime import datetime, timezone
+
+from rich.console import Console
+
+from firewheel.cli.utils import RichDefaultTable
+from firewheel.lib.minimega.api import minimegaAPI
+
+
+def format_bytes(num_bytes):
+    """
+    Convert a byte count to a human-readable string.
+
+    Args:
+        num_bytes (int): Size in bytes.
+
+    Returns:
+        str: Human-readable size string.
+    """
+    units = ["B", "KB", "MB", "GB", "TB", "PB"]
+    size = float(num_bytes)
+
+    for unit in units:
+        if size < 1024 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024
+
+    return f"{num_bytes} B"
+
+
+def normalize_cache_rows(rows):
+    """
+    Normalize mmr_map() cache rows into a stable machine-readable structure.
+
+    Args:
+        rows (list[dict]): Rows for a single host from mmr_map(file_list(...)).
+
+    Returns:
+        list[dict]: Normalized cache rows.
+    """
+    normalized_rows = []
+    for row in rows:
+        normalized_rows.append(
+            {
+                "dir": row.get("dir", ""),
+                "name": row.get("name", ""),
+                "size": int(row["size"]) if row.get("size") not in (None, "") else 0,
+                "modified": row.get("modified", ""),
+            }
+        )
+    return normalized_rows
+
+
+def get_single_host_rows(mapped_rows):
+    """
+    Extract rows for the single expected host.
+
+    Args:
+        mapped_rows (dict): Output from mm_api.mmr_map(mm_api.mm.file_list(...)).
+
+    Returns:
+        tuple[str | None, list[dict]]: The host name and its rows.
+    """
+    if not mapped_rows:
+        return None, []
+
+    host, rows = next(iter(mapped_rows.items()))
+    return host, rows
+
+
+def collect_cache_data():
+    """
+    Collect image and vm_resource cache contents.
+
+    Returns:
+        dict: Structured cache listing data.
+    """
+    mm_api = minimegaAPI()
+
+    vm_resources_raw = mm_api.mmr_map(mm_api.mm.file_list("vm_resources"))
+    images_raw = mm_api.mmr_map(mm_api.mm.file_list("images"))
+
+    vm_resources_host, vm_resources_rows = get_single_host_rows(vm_resources_raw)
+    images_host, images_rows = get_single_host_rows(images_raw)
+
+    host = vm_resources_host or images_host or mm_api.get_head_node()
+
+    vm_resources_entries = normalize_cache_rows(vm_resources_rows)
+    images_entries = normalize_cache_rows(images_rows)
+
+    return {
+        "host": host,
+        "vm_resources": {
+            "count": len(vm_resources_entries),
+            "entries": vm_resources_entries,
+        },
+        "images": {
+            "count": len(images_entries),
+            "entries": images_entries,
+        },
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def build_cache_table(title, host, rows):
+    """
+    Build a Rich table for one cache type.
+
+    Args:
+        title (str): Table title.
+        host (str): Host name.
+        rows (list[dict]): Cache rows.
+
+    Returns:
+        RichDefaultTable: The rendered table.
+    """
+    table = RichDefaultTable(
+        title=f"{title} ({host})",
+        caption=f"Found [cyan]{len(rows)}[/] entries",
+    )
+    table.add_column("Name")
+    table.add_column("Size", justify="right")
+    table.add_column("Modified")
+
+    if not rows:
+        table.add_row("N/A", "N/A", "0 B", "N/A")
+        return table
+
+    for row in rows:
+        table.add_row(
+            row["name"],
+            format_bytes(row["size"]),
+            row["modified"],
+        )
+
+    return table
+
+
+def render_text(cache_data):
+    """
+    Render human-readable cache output using Rich tables.
+    """
+    console = Console()
+
+    console.print(
+        build_cache_table(
+            "VM Resources Cache",
+            cache_data["host"],
+            cache_data["vm_resources"]["entries"],
+        )
+    )
+    console.print()
+
+    console.print(
+        build_cache_table(
+            "Images Cache",
+            cache_data["host"],
+            cache_data["images"]["entries"],
+        )
+    )
+    console.print()
+
+
+def render_json(cache_data):
+    """
+    Render machine-readable cache output.
+    """
+    print(json.dumps(cache_data, indent=2))
+
+
+def main():
+    """
+    List the image and vm_resource cache directories.
+    """
+    parser = argparse.ArgumentParser(
+        description="List the image and vm_resource cache directories.",
+        prog="firewheel mm show_caches",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format. Defaults to text.",
+    )
+    args = parser.parse_args()
+
+    cache_data = collect_cache_data()
+
+    if args.format == "json":
+        render_json(cache_data)
+    else:
+        render_text(cache_data)
+
+
+if __name__ == "__main__":
+    main()
 DONE

--- a/src/firewheel/cli/helpers/pull/file
+++ b/src/firewheel/cli/helpers/pull/file
@@ -55,12 +55,14 @@ RUN LocalPython ON control
 #!/usr/bin/env python
 
 import sys
+import json
 import shlex
 import pickle
 import argparse
 import subprocess
 from time import sleep
 from pathlib import Path, PureWindowsPath
+from datetime import datetime, timezone
 
 from rich.console import Console
 from rich.progress import Progress, TextColumn, SpinnerColumn, TimeElapsedColumn
@@ -71,159 +73,200 @@ from firewheel.vm_resource_manager.schedule_db import ScheduleDb
 from firewheel.vm_resource_manager.schedule_entry import ScheduleEntry
 
 
-def handle_schedule_entry(name, file_name):
-    """Add a file transfer entry to the schedule for a specified VM.
+DEFAULT_ATTEMPTS = 24
+POLL_INTERVAL_SECONDS = 5
 
-    This function retrieves the schedule for a given virtual machine (VM)
-    from the database, creates a new schedule entry for transferring a
-    specified file, and updates the schedule in the database.
+class PullFileError(Exception):
+    """Expected operational error for the pull file helper.
 
     Args:
-        name (str): The name of the VM for which the schedule is being updated.
-        file_name (str): The name of the file to be transferred.
+        message (str): Human-readable error message.
+        error_type (str): Stable machine-readable error type.
     """
-    con = Console()
-    schedule_db = ScheduleDb()
-    pickled_schedule = schedule_db.get(name)
-    if not pickled_schedule:
-        con.print(f"[b red]Unable to get schedule for VM: [cyan]{name}")
-        sys.exit(1)
-    schedule = pickle.loads(pickled_schedule)
 
-    # ScheduleEntry will have been loaded prior to this point automatically.
+    def __init__(self, message, error_type):
+        """Initialize the exception.
+
+        Args:
+            message (str): Human-readable error message.
+            error_type (str): Stable machine-readable error type.
+        """
+        super().__init__(message)
+        self.message = message
+        self.error_type = error_type
+
+
+def build_error_result(filename, vm_name, destination, attempts, message, error_type):
+    """Build a structured error result.
+
+    Args:
+        filename (str): Requested VM file or directory path.
+        vm_name (str): VM hostname.
+        destination (str): Local destination path.
+        attempts (int): Maximum readiness check attempts requested.
+        message (str): Human-readable error message.
+        error_type (str): Stable machine-readable error type.
+
+    Returns:
+        dict: Structured error result.
+    """
+    return {
+        "success": False,
+        "vm_name": vm_name,
+        "host_found": False,
+        "windows_vm": False,
+        "host": None,
+        "requested_source": filename,
+        "destination": destination,
+        "resolved_transfer_path": None,
+        "attempts_requested": attempts,
+        "attempts_used": 0,
+        "poll_interval_seconds": POLL_INTERVAL_SECONDS,
+        "file_ready": False,
+        "schedule_entry_added": False,
+        "copied": False,
+        "cleanup_performed": False,
+        "message": message,
+        "error": {
+            "type": error_type,
+            "detail": message,
+        },
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def schedule_pull_transfer(name, file_name):
+    """Add a file transfer entry to the schedule for a specified VM.
+
+    Args:
+        name (str): The VM name whose schedule should be updated.
+        file_name (str): The file or directory name to pull from the VM.
+
+    Returns:
+        dict: Structured scheduling result information.
+
+    Raises:
+        PullFileError: If schedule lookup, decoding, or storage fails.
+    """
+    schedule_db = ScheduleDb()
+
+    try:
+        pickled_schedule = schedule_db.get(name)
+    except OSError as exc:
+        raise PullFileError(
+            f"Unable to access schedule database for VM '{name}': {exc}",
+            "schedule_db_error",
+        ) from exc
+
+    if not pickled_schedule:
+        raise PullFileError(
+            f"Unable to get schedule for VM: {name}",
+            "schedule_unavailable",
+        )
+
+    try:
+        schedule = pickle.loads(pickled_schedule)
+    except (pickle.PickleError, pickle.UnpicklingError, EOFError, ValueError, TypeError) as exc:
+        raise PullFileError(
+            f"Unable to decode schedule for VM '{name}': {exc}",
+            "schedule_decode_error",
+        ) from exc
+
     se = ScheduleEntry(-100000)
     se.add_file_transfer(file_name, interval=None)
     schedule.append(se)
-    schedule_db.put(name, pickle.dumps(schedule), None)
+
+    try:
+        schedule_db.put(name, pickle.dumps(schedule), None)
+    except (pickle.PickleError, OSError, TypeError, ValueError) as exc:
+        raise PullFileError(
+            f"Unable to store updated schedule for VM '{name}': {exc}",
+            "schedule_store_error",
+        ) from exc
+
+    return {
+        "schedule_entry_added": True,
+    }
 
 
-def call_scp(hostname, src, dest, max_attempts=24):
-    """Transfer a file from a remote host to a local destination using SCP.
-
-    This function checks if the specified file is ready for transfer on the
-    remote host and then uses SCP to copy the file to the local destination.
-    If the file is not ready, it will retry up to a specified number of
-    attempts.
+def resolve_vm_context(vm_name):
+    """Resolve VM host and platform context.
 
     Args:
-        hostname (str): The hostname or IP address of the remote host.
-        src (Path): The source file path on the remote host.
-        dest (Path): The destination path on the local machine.
-        max_attempts (int, optional): The maximum number of attempts to check
-            if the file is ready. Defaults to 24.
+        vm_name (str): VM hostname.
+
+    Returns:
+        dict: Structured VM context information.
+
+    Raises:
+        PullFileError: If the VM cannot be found.
     """
-    con = Console()
-    count = 1
-    num_sec = 5
-    lockfile = src.parent / f"{src.name}-lock"
-    with Progress(
-        TextColumn(
-            "[yellow]Checking if the file is ready..."
-        ),
-        SpinnerColumn(spinner_name="line"),
-        TimeElapsedColumn(),
-        console=con,
-    ) as progress:
-        progress.add_task(description="check file")
-        while True:
-            ex = subprocess.run(  # noqa: S602
-                shlex.split(
-                    "ssh -o LogLevel=error -o UserKnownHostsFile=/dev/null "
-                    f'-o StrictHostKeyChecking=no {hostname} "if [ -e {src} ] && '
-                    f'[ ! -e {lockfile} ]; then echo True; fi"'
-                ),
-                capture_output=True,
-                check=True,
-            )
-            out = ex.stdout.decode("utf-8").strip()
-            if out == "True":
-                break
-            if count >= max_attempts:
-                console.print(str(
-                    f"[b red]Unable to get file: [cyan]{src}[/cyan] from host "
-                    f"[cyan]{hostname}[/cyan]. If the file is very large, you may need "
-                    "to increase the [magenta]--attempts[/magenta]. "
-                    f"Each attempt waits for [cyan]{num_sec}[/cyan] seconds."
-                ))
-                sys.exit(1)
-            count += 1
-            sleep(num_sec)
-    subprocess.run(  # noqa: S602
-        "scp -r -o LogLevel=error -o UserKnownHostsFile=/dev/null "
-        f"-o StrictHostKeyChecking=no {hostname}:{src} {dest}",
-        shell=True,
-        check=True,
-    )
-    subprocess.run(  # noqa: S602
-        "ssh -o LogLevel=error -o UserKnownHostsFile=/dev/null "
-        f'-o StrictHostKeyChecking=no {hostname} "rm -rf {src}"',
-        shell=True,
-        check=True,
-    )
-    sys.exit(0)
-
-
-if __name__ == "__main__":
-
-    # Set the arguments
-    parser = argparse.ArgumentParser(
-        description="Extract files from VMs within a FIREWHEEL experiment",
-        prog="firewheel pull file",
-    )
-
-    parser.add_argument(
-        "--attempts",
-        type=int,
-        default=24,
-        help="Number of 5 second attempts to try before giving up",
-    )
-
-    parser.add_argument(
-        "filename",
-        help="The name of the file or directory on the VM to extract",
-    )
-
-    parser.add_argument(
-        "vm_name",
-        help="The hostname of the VM within the experiment from which to pull the files",
-    )
-
-    parser.add_argument(
-        "destination",
-        help="Local destination path for the files that were extracted from the VM",
-    )
-
-    args = parser.parse_args()
-
-    filename = args.filename
-    vm_name = args.vm_name
-    destination = args.destination
-
-    local_dest = Path(destination)
-    if not local_dest.exists():
-        local_dest.parent.mkdir(parents=True, exist_ok=True)
-
-    handle_schedule_entry(vm_name, filename)
-
     mm_api = minimegaAPI()
     mm_dict = mm_api.mm_vms()
-    host = mm_dict[vm_name]["hostname"]
 
-    console = Console()
+    if vm_name not in mm_dict:
+        raise PullFileError(
+            f"No VM '{vm_name}' found.",
+            "vm_not_found",
+        )
+
+    vm_info = mm_dict[vm_name]
+    windows_vm = "windows" in vm_info["image"]
+
+    return {
+        "host_found": True,
+        "windows_vm": windows_vm,
+        "host": vm_info["hostname"],
+        "vm_info": vm_info,
+    }
+
+
+def ensure_local_destination(destination):
+    """Ensure the local destination path can be used.
+
+    Args:
+        destination (str): Local destination path.
+
+    Returns:
+        Path: Local destination as a ``Path``.
+
+    Raises:
+        PullFileError: If the destination directory cannot be prepared.
+    """
+    local_dest = Path(destination)
+
+    try:
+        if not local_dest.exists():
+            local_dest.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise PullFileError(
+            f"Unable to prepare local destination '{local_dest}': {exc}",
+            "destination_prepare_error",
+        ) from exc
+
+    return local_dest
+
+
+def build_transfer_path(vm_name, filename, windows_vm):
+    """Build the expected local transfer path on the FIREWHEEL host.
+
+    Args:
+        vm_name (str): VM hostname.
+        filename (str): Requested file or directory path on the VM.
+        windows_vm (bool): Whether the VM is a Windows VM.
+
+    Returns:
+        Path: Resolved transfer path on the FIREWHEEL host.
+    """
     path = None
-    # Check if the VM is a Windows VM based on image name
-    if "windows" in mm_dict[vm_name]["image"]:
-        if not PureWindowsPath(filename.strip("/")).drive:
-            console.print(
-                f"[b red]Path from Windows VM [cyan]{vm_name}[/cyan] does not have a drive. "
-                "Assuming [magenta]C:[/magenta]"
-            )
-            path = (
-                Path(config["logging"]["root_dir"])
-                / "transfers"
-                / vm_name
-                / PureWindowsPath("C:", filename).as_posix()
-            )
+
+    if windows_vm and not PureWindowsPath(filename.strip("/")).drive:
+        path = (
+            Path(config["logging"]["root_dir"])
+            / "transfers"
+            / vm_name
+            / PureWindowsPath("C:", filename).as_posix()
+        )
 
     if path is None:
         path = (
@@ -233,5 +276,325 @@ if __name__ == "__main__":
             / PureWindowsPath(filename.strip("/")).as_posix()
         )
 
-    call_scp(host, path, local_dest, max_attempts=args.attempts)
+    return path
+
+
+def wait_for_transfer_ready(
+    hostname,
+    src,
+    max_attempts=DEFAULT_ATTEMPTS,
+    poll_interval_seconds=POLL_INTERVAL_SECONDS,
+    show_progress=True,
+):
+    """Wait until the extracted file is ready on the remote host.
+
+    Args:
+        hostname (str): Remote host where the transferred file will appear.
+        src (Path): Path to the transferred file on the remote host.
+        max_attempts (int): Maximum readiness-check attempts.
+        poll_interval_seconds (int): Seconds between readiness checks.
+        show_progress (bool): Whether to display a Rich spinner.
+
+    Returns:
+        dict: Structured readiness result metadata.
+
+    Raises:
+        PullFileError: If readiness checking fails or times out.
+    """
+    count = 1
+    lockfile = src.parent / f"{src.name}-lock"
+    total_wait_seconds = max_attempts * poll_interval_seconds
+
+    readiness_command = shlex.split(
+        "ssh -o LogLevel=error -o UserKnownHostsFile=/dev/null "
+        f'-o StrictHostKeyChecking=no {hostname} "if [ -e {src} ] && '
+        f'[ ! -e {lockfile} ]; then echo True; fi"'
+    )
+
+    if show_progress:
+        con = Console()
+        with Progress(
+            TextColumn("[yellow]Checking if the file is ready..."),
+            SpinnerColumn(spinner_name="line"),
+            TimeElapsedColumn(),
+            console=con,
+        ) as progress:
+            progress.add_task(description="check file")
+            while True:
+                try:
+                    ex = subprocess.run(
+                        readiness_command,
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                    )
+                except subprocess.CalledProcessError as exc:
+                    raise PullFileError(
+                        f"Unable to check readiness of '{src}' on host '{hostname}': {exc}",
+                        "readiness_check_failed",
+                    ) from exc
+
+                out = ex.stdout.strip()
+                if out == "True":
+                    return {
+                        "attempts_used": count,
+                        "file_ready": True,
+                        "poll_interval_seconds": poll_interval_seconds,
+                    }
+
+                if count >= max_attempts:
+                    raise PullFileError(
+                        f"Unable to get file '{src}' from host '{hostname}'. "
+                        f"Timed out after {max_attempts} attempts "
+                        f"({total_wait_seconds} seconds total wait time). "
+                        "If the file is very large, you may need to increase --attempts.",
+                        "file_ready_timeout",
+                    )
+
+                count += 1
+                sleep(poll_interval_seconds)
+
+    while True:
+        try:
+            ex = subprocess.run(
+                readiness_command,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise PullFileError(
+                f"Unable to check readiness of '{src}' on host '{hostname}': {exc}",
+                "readiness_check_failed",
+            ) from exc
+
+        out = ex.stdout.strip()
+        if out == "True":
+            return {
+                "attempts_used": count,
+                "file_ready": True,
+                "poll_interval_seconds": poll_interval_seconds,
+            }
+
+        if count >= max_attempts:
+            raise PullFileError(
+                f"Unable to get file '{src}' from host '{hostname}'. "
+                f"Timed out after {max_attempts} attempts "
+                f"({total_wait_seconds} seconds total wait time). "
+                "If the file is very large, you may need to increase --attempts.",
+                "file_ready_timeout",
+            )
+
+        count += 1
+        sleep(poll_interval_seconds)
+
+
+def perform_transfer(hostname, src, dest):
+    """Copy the transferred file back locally and clean it up remotely.
+
+    Args:
+        hostname (str): Remote host where the transferred file exists.
+        src (Path): Path to the transferred file on the remote host.
+        dest (Path): Local destination path.
+
+    Returns:
+        dict: Structured transfer result metadata.
+
+    Raises:
+        PullFileError: If SCP or remote cleanup fails.
+    """
+    try:
+        subprocess.run(
+            shlex.split(
+                "scp -r -o LogLevel=error -o UserKnownHostsFile=/dev/null "
+                f"-o StrictHostKeyChecking=no {hostname}:{src} {dest}"
+            ),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise PullFileError(
+            f"Unable to copy '{src}' from host '{hostname}' to '{dest}': {exc}",
+            "scp_failed",
+        ) from exc
+
+    try:
+        subprocess.run(
+            shlex.split(
+                "ssh -o LogLevel=error -o UserKnownHostsFile=/dev/null "
+                f'-o StrictHostKeyChecking=no {hostname} "rm -rf {src}"'
+            ),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise PullFileError(
+            f"Unable to remove remote transfer path '{src}' from host '{hostname}': {exc}",
+            "remote_cleanup_failed",
+        ) from exc
+
+    return {
+        "copied": True,
+        "cleanup_performed": True,
+    }
+
+
+def collect_pull_file_result(filename, vm_name, destination, attempts, show_progress=True):
+    """Execute validation, scheduling, polling, and transfer for pull file.
+
+    Args:
+        filename (str): File or directory path on the VM.
+        vm_name (str): VM hostname.
+        destination (str): Local destination path.
+        attempts (int): Maximum readiness-check attempts.
+        show_progress (bool): Whether to show human progress UI.
+
+    Returns:
+        dict: Structured result information.
+
+    Raises:
+        PullFileError: For expected operational failures.
+    """
+    vm_context = resolve_vm_context(vm_name)
+    local_dest = ensure_local_destination(destination)
+    schedule_result = schedule_pull_transfer(vm_name, filename)
+    transfer_path = build_transfer_path(vm_name, filename, vm_context["windows_vm"])
+    readiness_result = wait_for_transfer_ready(
+        vm_context["host"],
+        transfer_path,
+        max_attempts=attempts,
+        show_progress=show_progress,
+    )
+    transfer_result = perform_transfer(vm_context["host"], transfer_path, local_dest)
+
+    result = {
+        "success": True,
+        "vm_name": vm_name,
+        "host_found": vm_context["host_found"],
+        "windows_vm": vm_context["windows_vm"],
+        "host": vm_context["host"],
+        "requested_source": filename,
+        "destination": str(local_dest),
+        "resolved_transfer_path": str(transfer_path),
+        "attempts_requested": attempts,
+        "attempts_used": readiness_result["attempts_used"],
+        "poll_interval_seconds": readiness_result["poll_interval_seconds"],
+        "file_ready": readiness_result["file_ready"],
+        "schedule_entry_added": schedule_result["schedule_entry_added"],
+        "copied": transfer_result["copied"],
+        "cleanup_performed": transfer_result["cleanup_performed"],
+        "message": "Successfully pulled file from VM.",
+        "error": None,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    return result
+
+
+def render_text(result):
+    """Render human-readable output using Rich.
+
+    Args:
+        result (dict): Structured pull file result.
+    """
+    console = Console()
+
+    if not result["success"]:
+        console.print("[bold red]Pull failed[/bold red]")
+        console.print(f"[red]{result['message']}[/red]")
+        console.print(f"[cyan]VM:[/cyan] {result['vm_name']}")
+        console.print(f"[cyan]Source:[/cyan] {result['requested_source']}")
+        console.print(f"[cyan]Destination:[/cyan] {result['destination']}")
+        return
+
+    console.print("[bold green]Pull completed successfully[/bold green]")
+    console.print(f"[cyan]VM:[/cyan] {result['vm_name']}")
+    console.print(f"[cyan]Host:[/cyan] {result['host']}")
+    console.print(f"[cyan]Source:[/cyan] {result['requested_source']}")
+    console.print(f"[cyan]Destination:[/cyan] {result['destination']}")
+    console.print(
+        f"[cyan]Attempts used:[/cyan] "
+        f"{result['attempts_used']}/{result['attempts_requested']}"
+    )
+    console.print(f"\n[green]{result['message']}[/green]")
+
+
+def render_json(result):
+    """Render machine-readable JSON output.
+
+    Args:
+        result (dict): Structured pull file result.
+    """
+    print(json.dumps(result, indent=2))
+
+
+def main():
+    """Parse command-line arguments and execute pull file."""
+    parser = argparse.ArgumentParser(
+        description="Extract files from VMs within a FIREWHEEL experiment",
+        prog="firewheel pull file",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format. Defaults to text.",
+    )
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=DEFAULT_ATTEMPTS,
+        help=(
+            f"Number of {POLL_INTERVAL_SECONDS} second attempts to try before giving up. "
+            f"Defaults to {DEFAULT_ATTEMPTS}."
+        ),
+    )
+    parser.add_argument(
+        "filename",
+        help="The name of the file or directory on the VM to extract",
+    )
+    parser.add_argument(
+        "vm_name",
+        help="The hostname of the VM within the experiment from which to pull the files",
+    )
+    parser.add_argument(
+        "destination",
+        help="Local destination path for the files that were extracted from the VM",
+    )
+
+    args = parser.parse_args()
+    
+    if args.attempts < 1:
+        parser.error("--attempts must be at least 1")
+
+    try:
+        result = collect_pull_file_result(
+            args.filename,
+            args.vm_name,
+            args.destination,
+            args.attempts,
+            show_progress=(args.format == "text"),
+        )
+    except PullFileError as exc:
+        result = build_error_result(
+            args.filename,
+            args.vm_name,
+            args.destination,
+            args.attempts,
+            exc.message,
+            exc.error_type,
+        )
+
+    if args.format == "json":
+        render_json(result)
+    else:
+        render_text(result)
+
+    sys.exit(0 if result["success"] else 1)
+
+
+if __name__ == "__main__":
+    main()
 DONE

--- a/src/firewheel/cli/helpers/pull/file
+++ b/src/firewheel/cli/helpers/pull/file
@@ -2,15 +2,17 @@ AUTHOR
 FIREWHEEL Team
 DONE
 DESCRIPTION
-
 Pull a file or directory from a VM using the VM resource handler. This does not require that
-the VM is running a SSH server. Also, unlike :ref:`helper_scp`, there is no need
+the VM is running an SSH server. Also, unlike :ref:`helper_scp`, there is no need
 to use the :ref:`control_network_mc` model component since the VM resource handler has access to
 the VM through a serial port.
 
 All files get placed at the location specified on the command line.
 
-**Usage:**  ``firewheel pull file [-h] <filename> <vm hostname> <destination>``
+This Helper supports both human-readable text output and machine-readable
+JSON output.
+
+**Usage:**  ``firewheel pull file [-h] [--format {text,json}] [--attempts ATTEMPTS] <filename> <vm hostname> <destination>``
 
 Arguments
 +++++++++
@@ -22,26 +24,34 @@ Named Arguments
 
     Show help message and exit.
 
+.. option:: --format {text,json}
+
+    :default: ``text``
+
+    Select the output format. ``text`` prints a human-readable summary and shows
+    progress while waiting for the transferred file to become available.
+    ``json`` returns a structured JSON response.
+
 .. option:: --attempts
 
     :default: 24
 
-    Number of 5 second attempts to try before giving up
+    Number of 5 second attempts to try before giving up.
 
 Positional Arguments
 ^^^^^^^^^^^^^^^^^^^^
 
 .. option:: <filename>
 
-    The name of the file or directory on the VM to extract
+    The name of the file or directory on the VM to extract.
 
 .. option:: <vm hostname>
 
-    The hostname of the VM within the experiment from which to pull the files
+    The hostname of the VM within the experiment from which to pull the files.
 
 .. option:: <destination>
 
-    Local destination path for the files that were extracted from the VM
+    Local destination path for the files that were extracted from the VM.
 
 Example
 +++++++
@@ -49,6 +59,8 @@ Example
 ``firewheel pull file /tmp/test.txt host.root.net /tmp/myfile.txt``
 
 ``firewheel pull file /tmp/test host.root.net /tmp/mydir``
+
+``firewheel pull file --format json /tmp/test.txt host.root.net /tmp/myfile.txt``
 
 DONE
 RUN LocalPython ON control

--- a/src/firewheel/cli/helpers/pull/file
+++ b/src/firewheel/cli/helpers/pull/file
@@ -9,6 +9,11 @@ the VM through a serial port.
 
 All files get placed at the location specified on the command line.
 
+.. note::
+
+    When pulling from a Windows VM, if the requested path does not include an
+    explicit drive letter, FIREWHEEL assumes the path is on the ``C:`` drive.
+
 This Helper supports both human-readable text output and machine-readable
 JSON output.
 
@@ -261,6 +266,9 @@ def ensure_local_destination(destination):
 
 def build_transfer_path(vm_name, filename, windows_vm):
     """Build the expected local transfer path on the FIREWHEEL host.
+
+    For Windows VMs, if the requested path does not include an explicit drive,
+    this function assumes the file is on the ``C:`` drive.
 
     Args:
         vm_name (str): VM hostname.

--- a/src/firewheel/cli/helpers/push/file
+++ b/src/firewheel/cli/helpers/push/file
@@ -2,9 +2,8 @@ AUTHOR
 FIREWHEEL Team
 DONE
 DESCRIPTION
-
 Push a file to a VM using the VM resource handler. This does not require that
-the VM is running a SSH server. Also, unlike :ref:`helper_scp`, there is no need
+the VM is running an SSH server. Also, unlike :ref:`helper_scp`, there is no need
 to use the :ref:`control_network_mc` model component since the VM resource handler has access to
 the VM through a serial port.
 
@@ -18,8 +17,10 @@ All files get placed at the location specified on the command line.
 
     Any shell expansions (e.g. ``~``) used in the ``destination`` path are resolved **BEFORE** the file is pushed to the VM.
 
+This Helper supports both human-readable text output and machine-readable
+JSON output.
 
-**Usage:**  ``firewheel push file [-h] <filename> <vm hostname> <destination>``
+**Usage:**  ``firewheel push file [-h] [--format {text,json}] <filename> <vm hostname> <destination>``
 
 Arguments
 +++++++++
@@ -29,14 +30,21 @@ Named Arguments
 
 .. option:: -h, --help
 
-    Show this help message and exit
+    Show this help message and exit.
+
+.. option:: --format {text,json}
+
+    :default: ``text``
+
+    Select the output format. ``text`` prints a human-readable scheduling summary.
+    ``json`` returns a structured JSON response.
 
 Positional Arguments
 ^^^^^^^^^^^^^^^^^^^^
 
 .. option:: <filename>
 
-    The name of the file to push to the VM
+    The name of the file to push to the VM.
 
 .. option:: <vm hostname>
 
@@ -51,7 +59,7 @@ Example
 
 ``firewheel push file /tmp/test.txt host.root.net /tmp/myfile.txt``
 
-``firewheel push file /tmp/test.txt whost.root.net '/Users/User/Downloads/myfile.txt'``
+``firewheel push file --format json /tmp/test.txt host.root.net /tmp/myfile.txt``
 
 DONE
 RUN LocalPython ON control

--- a/src/firewheel/cli/helpers/push/file
+++ b/src/firewheel/cli/helpers/push/file
@@ -59,6 +59,8 @@ Example
 
 ``firewheel push file /tmp/test.txt host.root.net /tmp/myfile.txt``
 
+``firewheel push file /tmp/test.txt host.windows.net '/Users/User/Downloads/myfile.txt'``
+
 ``firewheel push file --format json /tmp/test.txt host.root.net /tmp/myfile.txt``
 
 DONE
@@ -128,6 +130,11 @@ def build_error_result(filename, vm_name, destination, message, error_type):
 def schedule_file_transfer(name, file_name, destination, windows):
     """
     Schedule a VM resource file transfer.
+
+    This function retrieves the schedule for a specified virtual machine (VM)
+    from the schedule database, adds a new schedule entry for transferring a
+    resource file to the VM, and updates the schedule in the database. It
+    supports both Unix-like and Windows file transfer commands.
 
     Args:
         name (str): VM name.

--- a/src/firewheel/cli/helpers/push/file
+++ b/src/firewheel/cli/helpers/push/file
@@ -58,9 +58,13 @@ RUN LocalPython ON control
 #!/usr/bin/env python
 
 import sys
+import json
 import pickle
 import argparse
 from pathlib import Path, PureWindowsPath
+from datetime import datetime, timezone
+
+from rich.console import Console
 
 import firewheel.vm_resource_manager.api as vrm_api
 from firewheel.lib.minimega.api import minimegaAPI
@@ -68,53 +72,239 @@ from firewheel.vm_resource_manager.schedule_db import ScheduleDb
 from firewheel.vm_resource_manager.schedule_entry import ScheduleEntry
 
 
-def handle_schedule_entry(name, file_name, destination, windows):
-    """Handle the scheduling of a VM resource file transfer.
+class PushFileError(Exception):
+    """Expected operational error for the push file helper."""
 
-    This function retrieves the schedule for a specified virtual machine (VM)
-    from the schedule database, adds a new schedule entry for transferring a
-    resource file to the VM, and updates the schedule in the database. It
-    supports both Unix-like and Windows file transfer commands.
+    def __init__(self, message, error_type):
+        super().__init__(message)
+        self.message = message
+        self.error_type = error_type
+
+
+def build_error_result(filename, vm_name, destination, message, error_type):
+    """
+    Build a structured error result.
 
     Args:
-        name (str): The name of the VM for which the schedule is being handled.
-        file_name (str): The name of the resource file to be transferred.
-        destination (str): The destination path on the VM where the file will be transferred.
-        windows (bool): A flag indicating whether the destination is a Windows environment.
+        filename (str): Local source path.
+        vm_name (str): VM hostname.
+        destination (str): Destination path on VM.
+        message (str): Human-readable error message.
+        error_type (str): Machine-readable error type.
+
+    Returns:
+        dict: Structured error result.
+    """
+    source_path = Path(filename)
+
+    return {
+        "success": False,
+        "vm_name": vm_name,
+        "host_found": False,
+        "windows_vm": False,
+        "source": str(source_path),
+        "source_exists": source_path.exists(),
+        "source_basename": source_path.name,
+        "destination": destination,
+        "resource_added": False,
+        "schedule_entry_added": False,
+        "message": message,
+        "error": {
+            "type": error_type,
+            "detail": message,
+        },
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def schedule_file_transfer(name, file_name, destination, windows):
+    """
+    Schedule a VM resource file transfer.
+
+    Args:
+        name (str): VM name.
+        file_name (str): Source file path on the local system.
+        destination (str): Destination path on the VM.
+        windows (bool): Whether the destination VM is a Windows VM.
+
+    Returns:
+        dict: Structured result data for the scheduled file transfer.
+
+    Raises:
+        PushFileError: For expected operational failures.
     """
     schedule_db = ScheduleDb()
-    pickled_schedule = schedule_db.get(name)
-    if not pickled_schedule:
-        print(f"Unable to get schedule for VM: {name}")
-        sys.exit(1)
-    schedule = pickle.loads(pickled_schedule)
 
-    print(f"Adding '{file_name}' as a VM Resource.")
+    try:
+        pickled_schedule = schedule_db.get(name)
+    except OSError as exc:
+        raise PushFileError(
+            f"Unable to access schedule database for VM '{name}': {exc}",
+            "schedule_db_error",
+        ) from exc
+
+    if not pickled_schedule:
+        raise PushFileError(
+            f"Unable to get schedule for VM: {name}",
+            "schedule_unavailable",
+        )
+
+    try:
+        schedule = pickle.loads(pickled_schedule)
+    except (pickle.PickleError, pickle.UnpicklingError, EOFError, ValueError, TypeError) as exc:
+        raise PushFileError(
+            f"Unable to decode schedule for VM '{name}': {exc}",
+            "schedule_decode_error",
+        ) from exc
+
+    try:
+        vrm_api.add_vm_resource_file(file_name)
+    except OSError as exc:
+        raise PushFileError(
+            f"Unable to add VM resource file '{file_name}': {exc}",
+            "vm_resource_add_error",
+        ) from exc
+
+    source_basename = Path(file_name).name
+
     se = ScheduleEntry(-100000, ignore_failure=True)
-    vrm_api.add_vm_resource_file(file_name)
-    file_name = Path(file_name).name
     if not windows:
-        print(f"Going to transfer '{Path(file_name)}' to destination "
-              f"'{Path(destination)}' on VM '{name}'.\n")
-        se.set_executable("mv", f"{file_name} {destination}")
+        se.set_executable("mv", f"{source_basename} {destination}")
+        rendered_destination = str(Path(destination))
+        transfer_command = "mv"
     else:
-        print(f"Going to transfer '{Path(file_name)}' to destination "
-              f"'{PureWindowsPath(destination)}' on VM '{name}'.\n")
-        se.set_executable("move", f"{file_name} {destination}")
-    se.add_file(file_name, file_name, False)
+        se.set_executable("move", f"{source_basename} {destination}")
+        rendered_destination = str(PureWindowsPath(destination))
+        transfer_command = "move"
+
+    se.add_file(source_basename, source_basename, False)
     schedule.append(se)
-    schedule_db.put(name, pickle.dumps(schedule), None)
-    print(
+
+    try:
+        schedule_db.put(name, pickle.dumps(schedule), None)
+    except (pickle.PickleError, OSError, TypeError, ValueError) as exc:
+        raise PushFileError(
+            f"Unable to store updated schedule for VM '{name}': {exc}",
+            "schedule_store_error",
+        ) from exc
+
+    return {
+        "resource_added": True,
+        "schedule_entry_added": True,
+        "source_basename": source_basename,
+        "rendered_destination": rendered_destination,
+        "transfer_command": transfer_command,
+    }
+
+
+def collect_push_file_result(filename, vm_name, destination):
+    """
+    Execute validation and scheduling for push file.
+
+    Args:
+        filename (str): Local source path.
+        vm_name (str): VM hostname.
+        destination (str): Destination path on VM.
+
+    Returns:
+        dict: Structured result information.
+
+    Raises:
+        PushFileError: For expected operational failures.
+    """
+    source_path = Path(filename)
+    if not source_path.exists():
+        raise PushFileError(
+            f"The file being pushed to the VM '{source_path}' does not exist!",
+            "file_not_found",
+        )
+
+    mm_api = minimegaAPI()
+    mm_dict = mm_api.mm_vms()
+
+    if vm_name not in mm_dict:
+        raise PushFileError(
+            f"No VM '{vm_name}' found.",
+            "vm_not_found",
+        )
+
+    vm_info = mm_dict[vm_name]
+    windows_vm = "windows" in vm_info["image"]
+
+    result = {
+        "success": False,
+        "vm_name": vm_name,
+        "host_found": True,
+        "windows_vm": windows_vm,
+        "source": str(source_path),
+        "source_exists": True,
+        "source_basename": source_path.name,
+        "destination": destination,
+        "resource_added": False,
+        "schedule_entry_added": False,
+        "message": "",
+        "error": None,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    schedule_result = schedule_file_transfer(
+        vm_name,
+        str(source_path),
+        destination,
+        windows_vm,
+    )
+    result.update(schedule_result)
+
+    result["success"] = True
+    result["message"] = (
         "Successfully added a new schedule entry. "
         "Pending any errors, the file will be added shortly. "
         "To investigate the progress, visit the VM's resource log file."
     )
 
+    return result
 
-if __name__ == "__main__":
+
+def render_text(result):
+    """
+    Render human-readable output using Rich.
+    """
+    console = Console()
+
+    if not result["success"]:
+        console.print("[bold red]Push failed[/bold red]")
+        console.print(f"[red]{result['message']}[/red]")
+        console.print(f"[cyan]Source:[/cyan] {result['source']}")
+        console.print(f"[cyan]VM:[/cyan] {result['vm_name']}")
+        console.print(f"[cyan]Destination:[/cyan] {result['destination']}")
+        return
+
+    console.print("[bold green]Push scheduled successfully[/bold green]")
+    console.print(f"[cyan]Source:[/cyan] {result['source']}")
+    console.print(f"[cyan]VM:[/cyan] {result['vm_name']}")
+    console.print(f"[cyan]Destination:[/cyan] {result['rendered_destination']}")
+    console.print(f"[cyan]Transfer command:[/cyan] {result['transfer_command']}")
+    console.print(f"\n[green]{result['message']}[/green]")
+
+
+def render_json(result):
+    """
+    Render machine-readable JSON output.
+    """
+    print(json.dumps(result, indent=2))
+
+
+def main():
     parser = argparse.ArgumentParser(
         description="Push a file to a VM using the VM resource handler.",
         prog="firewheel push file",
+    )
+
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format. Defaults to text.",
     )
 
     parser.add_argument(
@@ -135,20 +325,25 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if not Path(args.filename).exists():
-        raise FileNotFoundError(f"The file being pushed to the VM "
-                                f"'{Path(args.filename)}' does not exist!")
-
-    mm_api = minimegaAPI()
-    mm_dict = mm_api.mm_vms()
-    windows_vm = False
     try:
-        if "windows" in mm_dict[args.vm_name]["image"]:
-            windows_vm = True
-    except KeyError:
-        print(f"No VM '{args.vm_name}' found.")
-        sys.exit(1)
+        result = collect_push_file_result(args.filename, args.vm_name, args.destination)
+    except PushFileError as exc:
+        result = build_error_result(
+            args.filename,
+            args.vm_name,
+            args.destination,
+            exc.message,
+            exc.error_type,
+        )
 
-    handle_schedule_entry(args.vm_name, args.filename, args.destination,
-                          windows_vm)
+    if args.format == "json":
+        render_json(result)
+    else:
+        render_text(result)
+
+    sys.exit(0 if result["success"] else 1)
+
+
+if __name__ == "__main__":
+    main()
 DONE

--- a/src/firewheel/cli/helpers/repository/list
+++ b/src/firewheel/cli/helpers/repository/list
@@ -2,12 +2,34 @@ AUTHOR
 FIREWHEEL Team
 DONE
 DESCRIPTION
-Show all installed repositories.
+Show all installed Model Component repositories.
+
+This Helper supports both human-readable text output and machine-readable
+JSON output.
+
+Arguments
++++++++++
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+.. option:: -h, --help
+
+    Show help message and exit.
+
+.. option:: --format {text,json}
+
+    :default: ``text``
+
+    Select the output format. ``text`` prints repository paths in a simple list.
+    ``json`` returns a structured JSON response.
 
 Example
 +++++++
 
 ``firewheel repository list``
+
+``firewheel repository list --format json``
 
 DONE
 RUN Python ON control

--- a/src/firewheel/cli/helpers/repository/list
+++ b/src/firewheel/cli/helpers/repository/list
@@ -13,12 +13,65 @@ DONE
 RUN Python ON control
 #!/usr/bin/env python
 
+import json
+import argparse
+from datetime import datetime, timezone
+
 from firewheel.control.repository_db import RepositoryDb
 
-repo_db = RepositoryDb()
-repo_list = repo_db.list_repositories()
 
-print("Installed Model Component Repositories:")
-for entry in repo_list:
-    print(f"{entry['path']}")
+def collect_repository_list_data():
+    """Collect installed repository information.
+
+    Returns:
+        dict: Structured repository listing data.
+    """
+    repo_db = RepositoryDb()
+    repo_list = list(repo_db.list_repositories())
+
+    repositories = [{"path": entry["path"]} for entry in repo_list]
+
+    return {
+        "count": len(repositories),
+        "repositories": repositories,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def render_text(repo_data):
+    """Render human-readable repository list output."""
+    print("Installed Model Component Repositories:")
+    for entry in repo_data["repositories"]:
+        print(entry["path"])
+
+
+def render_json(repo_data):
+    """Render machine-readable repository list output."""
+    print(json.dumps(repo_data, indent=2))
+
+
+def main():
+    """List installed repositories."""
+    parser = argparse.ArgumentParser(
+        description="Show all installed repositories.",
+        prog="firewheel repository list",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format. Defaults to text.",
+    )
+    args = parser.parse_args()
+
+    repo_data = collect_repository_list_data()
+
+    if args.format == "json":
+        render_json(repo_data)
+    else:
+        render_text(repo_data)
+
+
+if __name__ == "__main__":
+    main()
 DONE

--- a/src/firewheel/cli/helpers/status
+++ b/src/firewheel/cli/helpers/status
@@ -14,33 +14,83 @@ DONE
 RUN Python ON control
 #!/usr/bin/env python
 
+import json
+import argparse
+from datetime import datetime, timezone
+
 import firewheel.vm_resource_manager.api as vrm_api
 from firewheel.lib.minimega.api import minimegaAPI
 
 
-def main():
-    """Check the status of the FIREWHEEL experiment and Minimega VMs.
+def collect_status_data():
+    """Collect FIREWHEEL testbed status information.
 
-    This function initializes the Minimega API and checks if there is an
-    ongoing FIREWHEEL experiment or if any VMs are currently running in
-    Minimega. It prints appropriate messages based on the status of the
-    experiment and VMs.
+    Returns:
+        dict: Structured status information.
     """
     mm_api = minimegaAPI()
-    if vrm_api.get_experiment_launch_time() is not None:
-        msg = (
-            "There is already a FIREWHEEL experiment running. To reset"
-            " the testbed use the command: 'firewheel restart'."
+    experiment_running = vrm_api.get_experiment_launch_time() is not None
+    minimega_vms_present = bool(mm_api.mm_vms())
+
+    if experiment_running:
+        message = (
+            "There is already a FIREWHEEL experiment running. "
+            "To reset the testbed use the command: 'firewheel restart'."
         )
-        print(msg)
-    elif mm_api.mm_vms():
-        msg = (
-            "There are already VMs running in minimega. To reset"
-            " the testbed use the command: 'firewheel restart'."
+        state = "experiment_running"
+        ready = False
+    elif minimega_vms_present:
+        message = (
+            "There are already VMs running in minimega. "
+            "To reset the testbed use the command: 'firewheel restart'."
         )
-        print(msg)
+        state = "minimega_vms_present"
+        ready = False
     else:
-        print("The testbed is ready to use!")
+        message = "The testbed is ready to use!"
+        state = "ready"
+        ready = True
+
+    return {
+        "ready": ready,
+        "state": state,
+        "experiment_running": experiment_running,
+        "minimega_vms_present": minimega_vms_present,
+        "message": message,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def render_text(status_data):
+    """Render human-readable status output."""
+    print(status_data["message"])
+
+
+def render_json(status_data):
+    """Render machine-readable JSON status output."""
+    print(json.dumps(status_data, indent=2))
+
+
+def main():
+    """Check the status of the FIREWHEEL experiment and Minimega VMs."""
+    parser = argparse.ArgumentParser(
+        description="Check whether the FIREWHEEL testbed is available.",
+        prog="firewheel status",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format. Defaults to text.",
+    )
+    args = parser.parse_args()
+
+    status_data = collect_status_data()
+
+    if args.format == "json":
+        render_json(status_data)
+    else:
+        render_text(status_data)
 
 
 if __name__ == "__main__":

--- a/src/firewheel/cli/helpers/status
+++ b/src/firewheel/cli/helpers/status
@@ -2,13 +2,35 @@ AUTHOR
 FIREWHEEL Team
 DONE
 DESCRIPTION
-This informs a user if the testbed is available for use or occupied by
-an existing experiment.
+Report whether the FIREWHEEL testbed is ready for use or appears to be occupied
+by an existing experiment or existing minimega VMs.
+
+This Helper supports both human-readable text output and machine-readable
+JSON output.
+
+Arguments
++++++++++
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+.. option:: -h, --help
+
+    Show help message and exit.
+
+.. option:: --format {text,json}
+
+    :default: ``text``
+
+    Select the output format. ``text`` prints a human-readable status message.
+    ``json`` returns a structured JSON response.
 
 Example
 +++++++
 
 ``firewheel status``
+
+``firewheel status --format json``
 
 DONE
 RUN Python ON control

--- a/src/firewheel/cli/helpers/status
+++ b/src/firewheel/cli/helpers/status
@@ -47,6 +47,10 @@ from firewheel.lib.minimega.api import minimegaAPI
 def collect_status_data():
     """Collect FIREWHEEL testbed status information.
 
+    This function initializes the Minimega API and checks if there is an
+    ongoing FIREWHEEL experiment or if any VMs are currently running in
+    Minimega.
+
     Returns:
         dict: Structured status information.
     """

--- a/src/firewheel/cli/helpers/time
+++ b/src/firewheel/cli/helpers/time
@@ -10,6 +10,9 @@ use the command ``date --utc``.
 If the experiment has started, the number of seconds since the experiment
 started is also printed.
 
+This Helper supports both human-readable text output and machine-readable
+JSON output.
+
 Arguments
 +++++++++
 All arguments are optional.
@@ -21,16 +24,23 @@ Named Arguments
 
     Show help message and exit.
 
+.. option:: --format {text,json}
+
+    :default: ``text``
+
+    Select the output format. ``text`` prints a human-readable summary.
+    ``json`` returns a structured JSON response.
+
 .. option:: --json
 
-    Dump output as JSON-formatted dictionary in the form of ``{start_time: <datetime>, seconds_since_start: <int>}``
+    Backward-compatible alias for ``--format json``.
 
 Example
 +++++++
 
 ``firewheel time``
 
-``firewheel time --json``
+``firewheel time --format json``
 
 DONE
 RUN LocalPython ON control

--- a/src/firewheel/cli/helpers/time
+++ b/src/firewheel/cli/helpers/time
@@ -148,7 +148,6 @@ def main():
         "--json",
         action="store_true",
         default=False,
-        deprecated=True,
         help=argparse.SUPPRESS,
     )
 

--- a/src/firewheel/cli/helpers/time
+++ b/src/firewheel/cli/helpers/time
@@ -148,6 +148,7 @@ def main():
         "--json",
         action="store_true",
         default=False,
+        deprecated=True,
         help=argparse.SUPPRESS,
     )
 

--- a/src/firewheel/cli/helpers/time
+++ b/src/firewheel/cli/helpers/time
@@ -33,80 +33,125 @@ Example
 ``firewheel time --json``
 
 DONE
-RUN Python ON control
+RUN LocalPython ON control
 #!/usr/bin/env python
 
 import json
 import argparse
+from datetime import datetime, timezone
+
+from rich.console import Console
 
 import firewheel.vm_resource_manager.api as vm_resource_api
 
 
-def start_time(args):
-    """Display the start time of the experiment and the elapsed time since it started.
+def collect_time_data():
+    """
+    Collect experiment time information.
 
-    This function retrieves the experiment's start time and the number of seconds
-    since the experiment began. It prints the information in either a human-readable
-    format or as a JSON object, depending on the command-line arguments provided.
-
-    Args:
-        args (argparse.Namespace): The command-line arguments parsed by the
-            argparse module. Should include a flag ``--json`` to determine
-            the output format.
+    Returns:
+        dict: Structured experiment time data.
     """
     experiment_time = vm_resource_api.get_experiment_start_time()
     seconds_since_start = vm_resource_api.get_experiment_time_since_start()
 
-    # Time zone is UTC by definition.
-    if experiment_time:
-        experiment_time = experiment_time.strftime("%m-%d-%Y %H:%M:%S")
+    start_time_iso = None
+    start_time_display = None
+    experiment_time_known = experiment_time is not None
+    experiment_started = False
+    message = "Experiment start time not yet determined."
 
-    if seconds_since_start:
+    if experiment_time is not None:
+        experiment_time_utc = experiment_time.astimezone(timezone.utc)
+        start_time_iso = experiment_time_utc.isoformat()
+        start_time_display = experiment_time_utc.strftime("%m-%d-%Y %H:%M:%S UTC")
+
+    if seconds_since_start is not None:
         seconds_since_start = int(seconds_since_start)
+        experiment_started = seconds_since_start > 0
 
-    if args.json:
-        print_obj = {"start_time": None, "seconds_since_start": None}
-        if experiment_time is not None:
-            print_obj["start_time"] = f"{experiment_time} UTC"
-        if seconds_since_start is not None:
-            print_obj["seconds_since_start"] = seconds_since_start
-        print(json.dumps(print_obj, indent=0))
-    else:
-        if experiment_time is not None:
-            print(f"Experiment start time: {experiment_time} UTC")
-        if seconds_since_start is not None:
-            if seconds_since_start > 0:
-                print(f"Experiment started {seconds_since_start} seconds ago")
-            else:
-                print(f"Experiment will start in {abs(seconds_since_start)} seconds")
+        if seconds_since_start > 0:
+            message = f"Experiment started {seconds_since_start} seconds ago"
         else:
-            print("Experiment start time not yet determined.")
+            message = f"Experiment will start in {abs(seconds_since_start)} seconds"
+    elif experiment_time is not None:
+        message = "Experiment start time determined, but elapsed time is not available."
+
+    return {
+        "start_time": start_time_iso,
+        "start_time_display": start_time_display,
+        "seconds_since_start": seconds_since_start,
+        "experiment_time_known": experiment_time_known,
+        "experiment_started": experiment_started,
+        "message": message,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def render_text(time_data):
+    """
+    Render human-readable experiment time output using Rich.
+    """
+    console = Console()
+
+    if time_data["start_time_display"] is not None:
+        console.print(
+            f"[green]Experiment start time:[/green] "
+            f"[cyan]{time_data['start_time_display']}[/cyan]"
+        )
+
+    if time_data["seconds_since_start"] is not None:
+        if time_data["seconds_since_start"] > 0:
+            console.print(f"[green]{time_data['message']}[/green]")
+        else:
+            console.print(f"[yellow]{time_data['message']}[/yellow]")
+    elif time_data["start_time_display"] is None:
+        console.print("[yellow]Experiment start time not yet determined.[/yellow]")
+    else:
+        console.print(f"[yellow]{time_data['message']}[/yellow]")
+
+
+def render_json(time_data):
+    """
+    Render machine-readable JSON output.
+    """
+    json_data = dict(time_data)
+    json_data.pop("start_time_display", None)
+    print(json.dumps(json_data, indent=2))
 
 
 def main():
-    """Parse command-line arguments and execute the start_time function.
-
-    This function sets up the command-line interface for the FIREWHEEL
-    Experiment Start Time tool. It defines the available arguments, including
-    an option to output results in JSON format. Upon parsing the arguments,
-    it calls the `start_time` function with the parsed arguments.
     """
-    parser = argparse.ArgumentParser(description="FIREWHEEL Experiment Start Time")
-
-    # VMs
-    parser.set_defaults(command=start_time)
+    Parse command-line arguments and display experiment time information.
+    """
+    parser = argparse.ArgumentParser(
+        description="FIREWHEEL Experiment Start Time",
+        prog="firewheel time",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format. Defaults to text.",
+    )
     parser.add_argument(
         "--json",
         action="store_true",
         default=False,
-        help=(
-            "Dump output as JSON-formatted dictionary in the form "
-            "of ``{start_time: <datetime>, seconds_since_start: <int>}``"  # noqa: FS003
-        ),
+        help=argparse.SUPPRESS,
     )
 
     args = parser.parse_args()
-    args.command(args)
+
+    if args.json:
+        args.format = "json"
+
+    time_data = collect_time_data()
+
+    if args.format == "json":
+        render_json(time_data)
+    else:
+        render_text(time_data)
 
 
 if __name__ == "__main__":

--- a/src/firewheel/cli/helpers/vm/list
+++ b/src/firewheel/cli/helpers/vm/list
@@ -516,7 +516,6 @@ def main():
     parser.add_argument(
         "--csv",
         action="store_true",
-        deprecated=True,
         help="Print the result into CSV-formatted rows instead of a pretty table.",
     )
     parser.add_argument(

--- a/src/firewheel/cli/helpers/vm/list
+++ b/src/firewheel/cli/helpers/vm/list
@@ -64,8 +64,11 @@ DONE
 RUN LocalPython ON control
 #!/usr/bin/env python
 
+import sys
+import json
 import argparse
 from collections import OrderedDict
+from datetime import datetime, timezone
 
 from rich.console import Console
 
@@ -74,43 +77,36 @@ from firewheel.cli.utils import RichDefaultTable
 from firewheel.lib.minimega.api import minimegaAPI
 
 
-def _parse_image(entity):
-    for dev in entity["devices"]:
-        if dev["name"] == "drive":
-            try:
-                return dev["db_path"]
-            except KeyError:
-                pass
-    return ""
-
-
-def _parse_vnc_port(entity):
-    for dev in entity["devices"]:
-        if dev["name"] == "vnc":
-            try:
-                return str(int(dev["port"]) + 5900)
-            except KeyError:
-                pass
-    return ""
-
-
-def vm_list(args):
-    """
-    List VMs, including the given fields in output. Possible fields are:
-        uuid
-        state
-        image
-        hostname
-        VNC port
-        name
-        time
-        ip
+class VmListError(Exception):
+    """Expected operational error for the vm list helper.
 
     Args:
-        args (argparse.Namespace): The arguments for ``vm list``.
+        message (str): Human-readable error message.
+        error_type (str): Stable machine-readable error type.
     """
-    # Figure out our filters for the database.
-    valid_db_filters = [
+
+    def __init__(self, message, error_type):
+        """Initialize the exception.
+
+        Args:
+            message (str): Human-readable error message.
+            error_type (str): Stable machine-readable error type.
+        """
+        super().__init__(message)
+        self.message = message
+        self.error_type = error_type
+
+
+def parse_requested_fields(raw_fields):
+    """Parse requested fields and filters from CLI input.
+
+    Args:
+        raw_fields (list[str]): Raw positional field arguments.
+
+    Returns:
+        collections.OrderedDict: Ordered mapping of field name to optional filter value.
+    """
+    valid_fields = [
         "uuid",
         "state",
         "image",
@@ -120,195 +116,426 @@ def vm_list(args):
         "time",
         "ip",
     ]
-    filters = OrderedDict()
-    for field in args.fields:
+
+    parsed_fields = OrderedDict()
+    for field in raw_fields:
         field_vals = field.split("=")
-        if field_vals[0] in valid_db_filters:
+        field_name = field_vals[0]
+        if field_name in valid_fields:
             if len(field_vals) > 1:
-                filters[field_vals[0]] = field_vals[1]
-            elif field_vals[0] not in filters:
-                filters[field_vals[0]] = None
+                parsed_fields[field_name] = field_vals[1]
+            elif field_name not in parsed_fields:
+                parsed_fields[field_name] = None
 
-    # Get the basic info.
-    mm_api = minimegaAPI()
-    basic_dict = mm_api.mm_vms()
+    if len(parsed_fields) == 0:
+        parsed_fields = OrderedDict({"state": None})
 
-    # Build a list of basic fields to print (their list index value).
-    # Also build the table header while we do this.
-    # The code construction for this processing creates the table with the
-    #  columns in the order specified by the user as a deliberate side effect.
-    basic_fields = []
+    return parsed_fields
+
+
+def style_state_display(state_display):
+    """Apply Rich styling to a VM state display string.
+
+    Args:
+        state_display (str): Combined display string for state.
+
+    Returns:
+        str: Rich-styled state string.
+    """
+    if "configuring" in state_display.lower():
+        return f"[yellow]{state_display}"
+    if "configured" in state_display.lower():
+        return f"[green]{state_display}"
+    if "uninitialized" in state_display.lower():
+        return f"[yellow]{state_display}"
+    if "error" in state_display.lower():
+        return f"[red]{state_display}"
+    if "pause" in state_display.lower():
+        return f"[yellow]{state_display}"
+    if "run" in state_display.lower():
+        return f"[green]{state_display}"
+    return state_display
+
+
+def filter_basic_vm_data(basic_dict, requested_fields):
+    """Filter VMs using filters that can be applied directly to basic VM data.
+
+    Args:
+        basic_dict (dict): Raw VM dictionary from minimega.
+        requested_fields (collections.OrderedDict): Requested fields and optional filters.
+
+    Returns:
+        dict: Filtered VM dictionary.
+    """
     vm_resource_fields = {"state", "time"}
-    table_header = ["Name"]
-    # If state is in our included fields, get the vm_resource state info too.
+
+    if not requested_fields or all(value is None for value in requested_fields.values()):
+        return {vm: vm_dict.copy() for vm, vm_dict in basic_dict.items()}
+
     filtered_dict = {}
-    if not filters or all(value is None for value in filters.values()):
-        filtered_dict = basic_dict
-    else:
-        # Only add vms that contain all set filter values
-        for vm, vm_dict in basic_dict.items():
-            vm_obeys_filters = True
-            for key, value in filters.items():
-                if value is None:
-                    continue
-                if key not in vm_resource_fields:
-                    if value.lower() not in vm_dict[key].lower():
-                        vm_obeys_filters = False
-                        break
-            if vm_obeys_filters:
-                filtered_dict[vm] = vm_dict
+    for vm, vm_dict in basic_dict.items():
+        vm_obeys_filters = True
+        for key, value in requested_fields.items():
+            if value is None:
+                continue
+            if key not in vm_resource_fields:
+                if key == "ip":
+                    candidate = vm_dict.get("control_ip", "")
+                else:
+                    candidate = vm_dict.get(key, "")
+                if value.lower() not in str(candidate).lower():
+                    vm_obeys_filters = False
+                    break
+        if vm_obeys_filters:
+            filtered_dict[vm] = vm_dict.copy()
 
-    # Determine whether experiment has started.
+    return filtered_dict
+
+
+def enrich_time_data(filtered_dict, requested_fields):
+    """Add time data to filtered VM records.
+
+    Args:
+        filtered_dict (dict): Filtered VM dictionary.
+        requested_fields (collections.OrderedDict): Requested fields and optional filters.
+
+    Returns:
+        dict: Updated filtered VM dictionary with time fields populated.
+    """
+    if "time" not in requested_fields:
+        return filtered_dict
+
     experiment_time = vm_resource_api.get_experiment_start_time()
+    time_filter = requested_fields["time"]
+    vm_time_dict = vm_resource_api.get_vm_times(time_filter)
 
-    # Have a sensible default field if none are given.
-    if len(filters) == 0:
-        filters = {"state": None}
+    if time_filter:
+        filtered_dict = {k: v for k, v in filtered_dict.items() if k in vm_time_dict}
 
-    for field, filter_val in filters.items():
-        new_filtered_dict = None
+    for vm in filtered_dict:
+        if vm in vm_time_dict:
+            if not vm_time_dict[vm]:
+                filtered_dict[vm]["time"] = None
+                filtered_dict[vm]["time_display"] = "N/A"
+            elif experiment_time:
+                filtered_dict[vm]["time"] = vm_time_dict[vm]
+                filtered_dict[vm]["time_display"] = " :)"
+            else:
+                filtered_dict[vm]["time"] = vm_time_dict[vm]
+                filtered_dict[vm]["time_display"] = str(vm_time_dict[vm])
+        else:
+            filtered_dict[vm]["time"] = None
+            filtered_dict[vm]["time_display"] = "N/A"
 
-        if field == "time":
-            basic_fields.append("time")
-            table_header.append("Time")
+    return filtered_dict
 
-            vm_resource_dict = vm_resource_api.get_vm_times(filter_val)
-            if filter_val:
-                filtered_dict = {
-                    k: v for k, v in filtered_dict.items() if k in vm_resource_dict
-                }
-            for vm in filtered_dict:
-                if vm in vm_resource_dict:
-                    if not vm_resource_dict[vm]:
-                        filtered_dict[vm]["time"] = "N/A"
-                    elif experiment_time:
-                        # experiment has started, so we overwrite vm time.
-                        filtered_dict[vm]["time"] = " :)"
-                    else:
-                        # report time of most recently run vm_resource (should be negative).
-                        filtered_dict[vm]["time"] = vm_resource_dict[vm]
-                else:
-                    filtered_dict[vm]["time"] = "N/A"
 
-        if field == "uuid":
-            basic_fields.append("uuid")
-            table_header.append("UUID")
+def enrich_state_data(filtered_dict, requested_fields):
+    """Add state data to filtered VM records.
 
-        if field == "state":
-            basic_fields.append("state")
-            table_header.append("State")
+    Args:
+        filtered_dict (dict): Filtered VM dictionary.
+        requested_fields (collections.OrderedDict): Requested fields and optional filters.
 
-            if filter_val:
-                filtered_vm_resource_dict = vm_resource_api.get_vm_states(filter_val)
-                # By filtering on vm_resource state, we need to remove any vm
-                # in filtered_dict that is not returned in filtered_vm_resource_dict
-                filtered_dict = {
-                    k: v
-                    for k, v in filtered_dict.items()
-                    if k in filtered_vm_resource_dict or filter_val.lower() in v["state"].lower()
-                }
+    Returns:
+        dict: Updated filtered VM dictionary with state fields populated.
+    """
+    if "state" not in requested_fields:
+        return filtered_dict
 
-            # Format for printing
-            vm_resource_dict = vm_resource_api.get_vm_states()
-            for vm in filtered_dict:
-                if vm in vm_resource_dict:
-                    state_string = (
-                        f"{filtered_dict[vm]['state']}/{vm_resource_dict[vm]}"
-                    )
-                else:
-                    state_string = f"{filtered_dict[vm]['state']}/ERROR"
-                if "configuring" in state_string.lower():
-                    state_string = f"[yellow]{state_string}"
-                if "configured" in state_string.lower():
-                    state_string = f"[green]{state_string}"
-                if "uninitialized" in state_string.lower():
-                    state_string = f"[yellow]{state_string}"
-                if "error" in state_string.lower():
-                    state_string = f"[red]{state_string}"
-                filtered_dict[vm]["state"] = state_string
-        if field == "hostname":
-            basic_fields.append("hostname")
-            table_header.append("Hostname")
+    state_filter = requested_fields["state"]
 
-        if field == "vnc":
-            basic_fields.append("vnc")
-            table_header.append("VNC Port")
+    if state_filter:
+        filtered_vm_resource_dict = vm_resource_api.get_vm_states(state_filter)
+        filtered_dict = {
+            k: v
+            for k, v in filtered_dict.items()
+            if k in filtered_vm_resource_dict
+            or state_filter.lower() in v["state"].lower()
+        }
 
-        if field == "image":
-            basic_fields.append("image")
-            table_header.append("Image")
+    vm_resource_dict = vm_resource_api.get_vm_states()
+    for vm in filtered_dict:
+        power_state = filtered_dict[vm]["state"]
+        vm_resource_state = vm_resource_dict.get(vm, "ERROR")
 
-        if field == "ip":
-            basic_fields.append("control_ip")
-            table_header.append("Control IP")
+        filtered_dict[vm]["power_state"] = power_state
+        filtered_dict[vm]["vm_resource_state"] = vm_resource_state
+        filtered_dict[vm]["state_display"] = f"{power_state}/{vm_resource_state}"
 
-        # Must explicitly compare to None, otherwise this will also match an
-        # empty dictionary, causing us to find everything for queries that
-        # should return nothing.
-        if new_filtered_dict is not None:
-            filtered_dict = new_filtered_dict
+    return filtered_dict
 
-    # Build the table rows.
+
+def build_rows(filtered_dict, requested_fields):
+    """Build normalized result rows from filtered VM data.
+
+    Args:
+        filtered_dict (dict): Filtered and enriched VM dictionary.
+        requested_fields (collections.OrderedDict): Requested fields and optional filters.
+
+    Returns:
+        list[dict]: Normalized output rows.
+    """
     rows = []
+
     for vm in sorted(filtered_dict):
-        current_row = []
-        current_row.append(vm)
-        for field in basic_fields:
-            current_row.append(filtered_dict[vm][field])
-        rows.append(current_row)
+        row = {"name": vm}
 
-    # Print the result in either CSV format or in a table.
-    if args.csv:
-        console = Console(no_color=True)
-        console.print(",".join(table_header))
-        for row in rows:
-            console.print(",".join(row))
-    else:
-        _draw_table(table_header, rows, len(filtered_dict))
+        for field in requested_fields:
+            if field == "name":
+                continue
+            if field == "uuid":
+                row["uuid"] = filtered_dict[vm].get("uuid", "")
+            elif field == "state":
+                row["state"] = {
+                    "power_state": filtered_dict[vm].get("power_state", ""),
+                    "vm_resource_state": filtered_dict[vm].get("vm_resource_state", ""),
+                    "display": filtered_dict[vm].get("state_display", ""),
+                }
+            elif field == "image":
+                row["image"] = filtered_dict[vm].get("image", "")
+            elif field == "hostname":
+                row["hostname"] = filtered_dict[vm].get("hostname", "")
+            elif field == "vnc":
+                row["vnc"] = filtered_dict[vm].get("vnc", "")
+            elif field == "time":
+                row["time"] = {
+                    "value": filtered_dict[vm].get("time"),
+                    "display": filtered_dict[vm].get("time_display", "N/A"),
+                }
+            elif field == "ip":
+                row["ip"] = filtered_dict[vm].get("control_ip", "")
+
+        rows.append(row)
+
+    return rows
 
 
-def _draw_table(header, rows, num_vms):
-    console = Console()
+def collect_vm_list_data(raw_fields):
+    """Collect structured VM listing data.
+
+    Filtering behavior matches the legacy helper semantics.
+
+    Args:
+        raw_fields (list[str]): Raw positional field arguments from the CLI.
+
+    Returns:
+        dict: Structured VM list data.
+
+    Raises:
+        VmListError: If VM data collection fails.
+    """
+    requested_fields = parse_requested_fields(raw_fields)
+
+    try:
+        mm_api = minimegaAPI()
+        basic_dict = mm_api.mm_vms()
+    except OSError as exc:
+        raise VmListError(
+            f"Unable to retrieve VM data from minimega: {exc}",
+            "vm_data_unavailable",
+        ) from exc
+
+    filtered_dict = filter_basic_vm_data(basic_dict, requested_fields)
+    filtered_dict = enrich_time_data(filtered_dict, requested_fields)
+    filtered_dict = enrich_state_data(filtered_dict, requested_fields)
+    rows = build_rows(filtered_dict, requested_fields)
+
+    return {
+        "query": {
+            "fields": list(requested_fields.keys()),
+            "filters": dict(requested_fields),
+        },
+        "count": len(rows),
+        "rows": rows,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def get_console_fields(vm_list_data):
+    """Get ordered fields for console/table/csv rendering.
+
+    Args:
+        vm_list_data (dict): Structured VM list data.
+
+    Returns:
+        list[str]: Ordered output fields with ``name`` first.
+    """
+    console_fields = ["name"]
+    for field in vm_list_data["query"]["fields"]:
+        if field != "name":
+            console_fields.append(field)
+    return console_fields
+
+
+def build_vm_list_table(vm_list_data):
+    """Build a Rich table for VM list output.
+
+    Args:
+        vm_list_data (dict): Structured VM list data.
+
+    Returns:
+        RichDefaultTable: Rendered table.
+    """
+    console_fields = get_console_fields(vm_list_data)
+
+    label_map = {
+        "name": "Name",
+        "uuid": "UUID",
+        "state": "State",
+        "image": "Image",
+        "hostname": "Hostname",
+        "vnc": "VNC Port",
+        "time": "Time",
+        "ip": "Control IP",
+    }
+
     table = RichDefaultTable(
         title="Current VMs",
         caption_style="bold magenta",
-        caption=f"Found [cyan]{num_vms}[/] VMs",
+        caption=f"Found [cyan]{vm_list_data['count']}[/] VMs",
     )
-    for head in header:
-        table.add_column(head)
-    for row in rows:
-        table.add_row(*row)
-    console.print("\n", table, "\n")
+
+    for field in console_fields:
+        table.add_column(label_map[field])
+
+    for row in vm_list_data["rows"]:
+        rendered_row = [row["name"]]
+
+        for field in console_fields[1:]:
+            if field == "state":
+                rendered_row.append(style_state_display(row["state"]["display"]))
+            elif field == "time":
+                rendered_row.append(row["time"]["display"])
+            else:
+                rendered_row.append(str(row.get(field, "")))
+
+        table.add_row(*rendered_row)
+
+    return table
+
+
+def render_table(vm_list_data):
+    """Render human-readable table output.
+
+    Args:
+        vm_list_data (dict): Structured VM list data.
+    """
+    console = Console()
+    console.print("\n", build_vm_list_table(vm_list_data), "\n")
+
+
+def render_csv(vm_list_data):
+    """Render CSV output.
+
+    Args:
+        vm_list_data (dict): Structured VM list data.
+    """
+    console_fields = get_console_fields(vm_list_data)
+
+    header_map = {
+        "name": "Name",
+        "uuid": "UUID",
+        "state": "State",
+        "image": "Image",
+        "hostname": "Hostname",
+        "vnc": "VNC Port",
+        "time": "Time",
+        "ip": "Control IP",
+    }
+
+    console = Console(no_color=True)
+    console.print(",".join(header_map[field] for field in console_fields))
+
+    for row in vm_list_data["rows"]:
+        csv_row = [row["name"]]
+
+        for field in console_fields[1:]:
+            if field == "state":
+                csv_row.append(row["state"]["display"])
+            elif field == "time":
+                csv_row.append(row["time"]["display"])
+            else:
+                csv_row.append(str(row.get(field, "")))
+
+        console.print(",".join(csv_row))
+
+
+def render_json(vm_list_data):
+    """Render JSON output.
+
+    Args:
+        vm_list_data (dict): Structured VM list data.
+    """
+    print(json.dumps(vm_list_data, indent=2))
+
+
+def build_json_error_result(error):
+    """Build a structured JSON error payload.
+
+    Args:
+        error (VmListError): Helper error.
+
+    Returns:
+        dict: Structured error payload.
+    """
+    return {
+        "success": False,
+        "error": {
+            "type": error.error_type,
+            "detail": error.message,
+        },
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 def main():
-    """
-    List all virtual machines.
-
-    This function sets up a command-line interface for listing virtual machines.
-    It allows users to specify which fields to display and whether to output the
-    results in CSV format.
-    """
-    parser = argparse.ArgumentParser(description="List all virtual machines", prog="vm list")
-
-    # VMs
-    parser.set_defaults(command=vm_list)
+    """List all virtual machines."""
+    parser = argparse.ArgumentParser(
+        description="List all virtual machines",
+        prog="firewheel vm list",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "csv"],
+        default="table",
+        help="Output format. Defaults to table.",
+    )
     parser.add_argument(
         "--csv",
         action="store_true",
-        help="Print the result into CSV-formatted" " rows instead of a pretty table.",
+        help="Print the result into CSV-formatted rows instead of a pretty table.",
     )
     parser.add_argument(
         "fields",
         metavar="fields",
         nargs="*",
-        help="A field to display for each found VM, in the form field[=filter]."
-        " Available fields are: uuid, state, image, hostname, "
-        "vnc, name, time",
+        help=(
+            "A field to display for each found VM, in the form field[=filter]. "
+            "Available fields are: uuid, state, image, hostname, vnc, name, time, ip."
+        ),
     )
 
     args = parser.parse_args()
-    args.command(args)
+
+    if args.csv:
+        args.format = "csv"
+
+    try:
+        vm_list_data = collect_vm_list_data(args.fields)
+    except VmListError as exc:
+        if args.format == "json":
+            print(json.dumps(build_json_error_result(exc), indent=2))
+        else:
+            Console().print(f"[bold red]ERROR:[/bold red] {exc.message}")
+        sys.exit(1)
+
+    if args.format == "json":
+        render_json(vm_list_data)
+    elif args.format == "csv":
+        render_csv(vm_list_data)
+    else:
+        render_table(vm_list_data)
 
 
 if __name__ == "__main__":

--- a/src/firewheel/cli/helpers/vm/list
+++ b/src/firewheel/cli/helpers/vm/list
@@ -9,6 +9,9 @@ of all filters. If multiple filters are used then anything that matches **all**
 of filters will be displayed. Filters will attempt substring matching so ensure that
 you provide enough of a substring to the filter to narrow down the displayed results.
 
+This Helper supports human-readable table output, CSV output, and machine-readable
+JSON output.
+
 Arguments
 +++++++++
 
@@ -21,9 +24,16 @@ Named Arguments
 
     Show help message and exit.
 
+.. option:: --format {table,json,csv}
+
+    :default: ``table``
+
+    Select the output format. ``table`` prints a human-readable table.
+    ``csv`` prints CSV-formatted output. ``json`` returns a structured JSON response.
+
 .. option:: --csv
 
-    Output in CSV format.
+    Backward-compatible alias for ``--format csv``.
 
 Positional Arguments
 ^^^^^^^^^^^^^^^^^^^^
@@ -41,8 +51,8 @@ Positional Arguments
     ``name``       The name of the VM
     ``state``      State of VM QEMU process and vm_resource run status
     ``image``      Full name of the base image of the VM
-    ``hostname``   The hostname as it was assigned in the experiment
-    ``vnc``        The shortened port number used to connect to the VM through VNC. Note, the real port number is 5900 + that shown
+    ``hostname``   The hostname of the FIREWHEEL host currently running the VM
+    ``vnc``        The VNC port used to connect to the VM
     ``time``       If VM is configuring, this displays the time of the vm_resource currently running within a VM. If VM has not started configuring, this displays N/A. If VM is configured, this displays 0, unless an experiment start time has been determined, in which case all VMs return :)
     ``ip``         The VMs :ref:`control_network_mc` IP address, if the experiment included the :ref:`control_network_mc` MC
     =============  ==================================================================================================================================
@@ -59,6 +69,8 @@ Example
 ``firewheel vm list name=root --csv``
 
 ``firewheel vm list image=vyos state``
+
+``firewheel vm list --format json image=vyos state``
 
 DONE
 RUN LocalPython ON control

--- a/src/firewheel/cli/helpers/vm/list
+++ b/src/firewheel/cli/helpers/vm/list
@@ -516,6 +516,7 @@ def main():
     parser.add_argument(
         "--csv",
         action="store_true",
+        deprecated=True,
         help="Print the result into CSV-formatted rows instead of a pretty table.",
     )
     parser.add_argument(

--- a/src/firewheel/cli/helpers/vm/log
+++ b/src/firewheel/cli/helpers/vm/log
@@ -1,14 +1,22 @@
 AUTHOR
 FIREWHEEL Team
 DONE
-DESCRIPTION
 
 Retrieve a log for the given VM. This enables users to easily access log files for VMs
 without intimate knowledge of where the VM resource logs are stored. Additionally, it enables
 easy parsing and data analysis of logs.
 
-All log output is directly piped to standard out and can be further examined using common
-command line tools such as ``less``, ``tail``, or ``grep``, just to name a few.
+By default, this Helper retrieves the standard VM resource log and writes it directly to
+standard output. This makes it easy to further examine the log using common command line
+tools such as ``less``, ``tail``, or ``grep``.
+
+This Helper can retrieve either the standard VM resource log or the JSON log artifact,
+and can return either raw text output or a structured JSON response.
+
+.. note::
+
+    The JSON log artifact is not necessarily a complete representation of the standard
+    VM resource log. It is a separate log stream intended for structured log messages.
 
 Arguments
 +++++++++
@@ -20,9 +28,23 @@ Named Arguments
 
     Show help message and exit.
 
+.. option:: --format {text,json}
+
+    :default: ``text``
+
+    Select the output format for this Helper. ``text`` writes the selected log artifact
+    directly to standard output. ``json`` returns a structured JSON response.
+
+.. option:: --log-type {text,json}
+
+    :default: ``text``
+
+    Select which VM log artifact to retrieve. ``text`` retrieves the standard VM resource
+    log. ``json`` retrieves the JSON log artifact.
+
 .. option:: -j, --json
 
-    Retrieve the JSON log rather than the standard log.
+    Backward-compatible alias for ``--log-type json``.
 
 Positional Arguments
 ^^^^^^^^^^^^^^^^^^^^
@@ -31,13 +53,16 @@ Positional Arguments
 
     The name of the VM for which the log should be retrieved.
 
-
 Example
 +++++++
 
 ``firewheel vm log host.root.net``
 
-``firewheel vm log --json host.root.net``
+``firewheel vm log --log-type json host.root.net``
+
+``firewheel vm log --format json host.root.net``
+
+``firewheel vm log --format json --log-type json host.root.net``
 
 ``firewheel vm log host.root.net | less``
 
@@ -45,69 +70,362 @@ DONE
 RUN LocalPython ON control
 #!/usr/bin/env python
 
+import sys
+import re
+import json
 import argparse
 import subprocess
 from pathlib import Path
+from datetime import datetime, timezone
+
+from rich.console import Console
 
 from firewheel.config import Config
 from firewheel.lib.minimega.api import minimegaAPI
 
 
-def vm_log(args):
-    """
-    Get the log from the specified VM.
-    This is typically in text format, but can also be in JSON format.
+TEXT_LOG_TYPE = "text"
+JSON_LOG_TYPE = "json"
+
+LOG_LINE_RE = re.compile(
+    r"^\[(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [A-Z]+) "
+    r"(?P<level>DEBUG|INFO|WARNING|ERROR|CRITICAL)\] "
+    r"(?P<message>.*)$"
+)
+
+
+class VmLogError(Exception):
+    """Expected operational error for the vm log helper.
 
     Args:
-        args (argparse.Namespace): The arguments for ``vm log``.
+        message (str): Human-readable error message.
+        error_type (str): Stable machine-readable error type.
+    """
+
+    def __init__(self, message, error_type):
+        """Initialize the exception.
+
+        Args:
+            message (str): Human-readable error message.
+            error_type (str): Stable machine-readable error type.
+        """
+        super().__init__(message)
+        self.message = message
+        self.error_type = error_type
+
+
+def build_error_result(vm_name, log_type, message, error_type):
+    """Build a structured error result.
+
+    Args:
+        vm_name (str): VM hostname.
+        log_type (str): Requested log artifact type.
+        message (str): Human-readable error message.
+        error_type (str): Stable machine-readable error type.
+
+    Returns:
+        dict: Structured error result.
+    """
+    return {
+        "success": False,
+        "vm_name": vm_name,
+        "log_type": log_type,
+        "host_found": False,
+        "host": None,
+        "log_path": None,
+        "log_artifact_complete": None,
+        "content": None,
+        "message": message,
+        "error": {
+            "type": error_type,
+            "detail": message,
+        },
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def parse_text_log_entries(text):
+    """Parse vm_resource_handler text logs into structured multiline entries.
+
+    A new log entry begins whenever a line matches the FIREWHEEL VM resource
+    handler log prefix format. Any non-matching line is treated as a continuation
+    of the previous log entry.
+
+    Args:
+        text (str): Raw text log contents.
+
+    Returns:
+        list[dict]: Structured parsed log entries.
+    """
+    entries = []
+    current_entry = None
+
+    for line in text.splitlines():
+        match = LOG_LINE_RE.match(line)
+        if match:
+            if current_entry is not None:
+                current_entry["raw_message"] = "\n".join(
+                    [current_entry["message"], *current_entry["continuation"]]
+                )
+                entries.append(current_entry)
+
+            current_entry = {
+                "timestamp": match.group("timestamp"),
+                "level": match.group("level"),
+                "message": match.group("message"),
+                "continuation": [],
+            }
+        else:
+            if current_entry is None:
+                current_entry = {
+                    "timestamp": None,
+                    "level": None,
+                    "message": line,
+                    "continuation": [],
+                }
+            else:
+                current_entry["continuation"].append(line)
+
+    if current_entry is not None:
+        current_entry["raw_message"] = "\n".join(
+            [current_entry["message"], *current_entry["continuation"]]
+        )
+        entries.append(current_entry)
+
+    return entries
+
+
+def parse_json_log_entries(text):
+    """Parse line-oriented JSON log artifact entries.
+
+    Args:
+        text (str): Raw JSON log artifact contents.
+
+    Returns:
+        list[dict]: Parsed JSON log entries.
 
     Raises:
-        RuntimeError: If the provided VM does not exist.
+        VmLogError: If a JSON log line cannot be parsed.
     """
-    # Get the basic info.
+    entries = []
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            entries.append(json.loads(stripped))
+        except json.JSONDecodeError as exc:
+            raise VmLogError(
+                f"Unable to parse JSON log line {line_number}: {exc}",
+                "json_log_parse_error",
+            ) from exc
+
+    return entries
+
+
+def resolve_vm_log_context(vm_name):
+    """Resolve VM host and log path context.
+
+    Args:
+        vm_name (str): VM hostname.
+
+    Returns:
+        dict: Structured VM log context.
+
+    Raises:
+        VmLogError: If the VM cannot be found.
+    """
     mm_api = minimegaAPI()
     basic_dict = mm_api.mm_vms()
 
-    if args.vm not in basic_dict:
-        raise RuntimeError(
-            f"No VM with name {args.vm} is found. " "Ensure a VM with that name exists."
+    if vm_name not in basic_dict:
+        raise VmLogError(
+            f"No VM with name {vm_name} is found. Ensure a VM with that name exists.",
+            "vm_not_found",
         )
 
     config = Config().get_config()
-    pathname = Path(config["logging"]["root_dir"]) / Path(
+    log_directory = Path(config["logging"]["root_dir"]) / Path(
         config["logging"]["vmr_log_dir"]
     )
-    filename = f"{args.vm}.log"
-    if args.json:
-        filename = f"{args.vm}.json"
-    pathname /= filename
 
-    command = ["ssh", basic_dict[args.vm]["hostname"], f"cat {pathname!s}"]
-    subprocess.run(command, check=True)
+    return {
+        "host_found": True,
+        "host": basic_dict[vm_name]["hostname"],
+        "log_directory": log_directory,
+    }
+
+
+def get_log_path(log_directory, vm_name, log_type):
+    """Build the remote log file path for the requested log type.
+
+    Args:
+        log_directory (Path): Directory containing VM resource logs.
+        vm_name (str): VM hostname.
+        log_type (str): Requested log type.
+
+    Returns:
+        Path: Full remote log path.
+    """
+    suffix = ".json" if log_type == JSON_LOG_TYPE else ".log"
+    return log_directory / f"{vm_name}{suffix}"
+
+
+def fetch_remote_log_content(host, log_path):
+    """Fetch remote VM log content using SSH.
+
+    Args:
+        host (str): Remote FIREWHEEL host.
+        log_path (Path): Full remote log path.
+
+    Returns:
+        str: Remote log content.
+
+    Raises:
+        VmLogError: If the log cannot be retrieved.
+    """
+    command = ["ssh", host, f"cat {log_path!s}"]
+
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise VmLogError(
+            f"Unable to retrieve log from host '{host}' at path '{log_path}': {exc}",
+            "log_retrieval_failed",
+        ) from exc
+
+    return result.stdout
+
+
+def collect_vm_log_result(vm_name, log_type):
+    """Collect structured VM log data.
+
+    Args:
+        vm_name (str): VM hostname.
+        log_type (str): Requested backing log artifact type.
+
+    Returns:
+        dict: Structured VM log result.
+
+    Raises:
+        VmLogError: For expected operational failures.
+    """
+    context = resolve_vm_log_context(vm_name)
+    log_path = get_log_path(context["log_directory"], vm_name, log_type)
+    raw_content = fetch_remote_log_content(context["host"], log_path)
+
+    if log_type == JSON_LOG_TYPE:
+        parsed_content = parse_json_log_entries(raw_content)
+        log_artifact_complete = False
+        message = (
+            "Retrieved VM JSON log artifact. This artifact may not contain all "
+            "information present in the standard log."
+        )
+    else:
+        parsed_content = parse_text_log_entries(raw_content)
+        log_artifact_complete = True
+        message = "Retrieved VM text log."
+
+    return {
+        "success": True,
+        "vm_name": vm_name,
+        "log_type": log_type,
+        "host_found": context["host_found"],
+        "host": context["host"],
+        "log_path": str(log_path),
+        "log_artifact_complete": log_artifact_complete,
+        "content": parsed_content,
+        "raw_content": raw_content,
+        "message": message,
+        "error": None,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def render_text(result):
+    """Render human-readable log output.
+
+    Args:
+        result (dict): Structured VM log result.
+    """
+    if not result["success"]:
+        Console().print(f"[bold red]ERROR:[/bold red] {result['message']}")
+        return
+
+    if result["log_type"] == JSON_LOG_TYPE:
+        print(result["raw_content"], end="")
+    else:
+        print(result["raw_content"], end="")
+
+
+def render_json(result):
+    """Render machine-readable JSON output.
+
+    Args:
+        result (dict): Structured VM log result.
+    """
+    json_result = dict(result)
+    json_result.pop("raw_content", None)
+    print(json.dumps(json_result, indent=2))
 
 
 def main():
-    """
-    Develop the CLI options and call the primary logging functions
-    for `vm log`.
-    """
+    """Parse CLI arguments and retrieve a VM log."""
     parser = argparse.ArgumentParser(
-        description="Get the log for a given VM", prog="vm log"
+        description="Get the log for a given VM",
+        prog="firewheel vm log",
     )
-
-    # VMs
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format. Defaults to text.",
+    )
+    parser.add_argument(
+        "--log-type",
+        choices=[TEXT_LOG_TYPE, JSON_LOG_TYPE],
+        default=TEXT_LOG_TYPE,
+        help="Which VM log artifact to retrieve. Defaults to text.",
+    )
     parser.add_argument(
         "-j",
         "--json",
         action="store_true",
-        help="Get the JSON log for the given VM.",
+        default=False,
+        help="Backward-compatible alias for retrieving the JSON log artifact.",
     )
     parser.add_argument(
-        "vm", help="The name of the VM for which the logs are requested."
+        "vm",
+        help="The name of the VM for which the logs are requested.",
     )
 
     args = parser.parse_args()
-    vm_log(args)
+
+    if args.json:
+        args.log_type = JSON_LOG_TYPE
+
+    try:
+        result = collect_vm_log_result(args.vm, args.log_type)
+    except VmLogError as exc:
+        result = build_error_result(
+            args.vm,
+            args.log_type,
+            exc.message,
+            exc.error_type,
+        )
+
+    if args.format == "json":
+        render_json(result)
+    else:
+        render_text(result)
+
+    sys.exit(0 if result["success"] else 1)
 
 
 if __name__ == "__main__":

--- a/src/firewheel/cli/helpers/vm/log
+++ b/src/firewheel/cli/helpers/vm/log
@@ -399,7 +399,6 @@ def main():
         "--json",
         action="store_true",
         default=False,
-        deprecated=True,
         help="Backward-compatible alias for retrieving the JSON log artifact.",
     )
     parser.add_argument(

--- a/src/firewheel/cli/helpers/vm/log
+++ b/src/firewheel/cli/helpers/vm/log
@@ -399,6 +399,7 @@ def main():
         "--json",
         action="store_true",
         default=False,
+        deprecated=True,
         help="Backward-compatible alias for retrieving the JSON log artifact.",
     )
     parser.add_argument(

--- a/src/firewheel/cli/helpers/vm/log
+++ b/src/firewheel/cli/helpers/vm/log
@@ -1,6 +1,7 @@
 AUTHOR
 FIREWHEEL Team
 DONE
+DESCRIPTION
 
 Retrieve a log for the given VM. This enables users to easily access log files for VMs
 without intimate knowledge of where the VM resource logs are stored. Additionally, it enables

--- a/src/firewheel/cli/helpers/vm/mix
+++ b/src/firewheel/cli/helpers/vm/mix
@@ -2,19 +2,41 @@ AUTHOR
 FIREWHEEL Team
 DONE
 DESCRIPTION
+Generates a view of the VM image mix for the current experiment. The output
+includes the VM image, the VM power state, the VM resource state, and the
+count of VMs in each grouped combination.
 
-Generates a table showing the VM Images for a running experiment. The table also
-includes the power state of the VMs and the vm_resource state. Images that are the same
-and have the same power/vm_resource state are grouped. The count of the various VMs are
-provided. Additionally, the total number of scheduled VMs is shown at the bottom
-of the table.
+VMs with the same image, power state, and VM resource state are grouped
+together. The total number of scheduled VMs is also reported.
+
+This Helper supports both human-readable table output and machine-readable
+JSON output.
+
+Arguments
++++++++++
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+.. option:: -h, --help
+
+    Show help message and exit.
+
+.. option:: --format {table,json}
+
+    :default: ``table``
+
+    Select the output format. ``table`` displays a live-updating human-readable
+    table. ``json`` returns a one-time structured JSON snapshot.
 
 Example
 +++++++
 
 ``firewheel vm mix``
 
-The output will look similar to the below table.::
+``firewheel vm mix --format json``
+
+The table output will look similar to the below.::
 
     +------------------------------------------------+-------------+----------------------+-------+
     |                    VM Image                    | Power State |  VM Resource State   | Count |

--- a/src/firewheel/cli/helpers/vm/mix
+++ b/src/firewheel/cli/helpers/vm/mix
@@ -30,7 +30,10 @@ RUN LocalPython ON control
 #!/usr/bin/env python
 
 import sys
+import json
+import argparse
 from time import sleep
+from datetime import datetime, timezone
 
 from rich.live import Live
 from rich.console import Console
@@ -40,77 +43,109 @@ from firewheel.cli.utils import RichDefaultTable
 from firewheel.lib.minimega.api import minimegaAPI
 
 
-def vm_mix():
+def collect_vm_mix_data():
     """
-    Create a table showing the mix of VMs in the current experiment.
+    Collect structured VM mix data for the current experiment.
 
     Returns:
-        table (firewheel.cli.RichDefaultTable): A table giving the mix of VMs in the experiment.
+        dict: Structured VM mix data suitable for rendering as either a table
+            or JSON.
     """
     mm_api = minimegaAPI()
     mm_vms = mm_api.mm_vms()
 
     active_exp_present = False
-    # Check if an experiment is running
-    if vm_resource_api.get_experiment_launch_time() is not None or mm_api.mm_vms():
+    if vm_resource_api.get_experiment_launch_time() is not None or mm_vms:
         active_exp_present = True
 
-    mm_state_dict = {}
+    rows = []
+    total_scheduled = 0
+
     if active_exp_present:
         vm_resource_vms = vm_resource_api.get_vm_states()
 
+        grouped = {}
         for vm_name, vm_dict in mm_vms.items():
             mm_state = vm_dict["state"]
             vm_resource_state = vm_resource_vms.get(vm_name, "None")
+            image = vm_dict["image"]
 
-            if mm_state not in mm_state_dict:
-                mm_state_dict[mm_state] = {}
-            if vm_resource_state not in mm_state_dict[mm_state]:
-                mm_state_dict[mm_state][vm_resource_state] = []
-
-            mm_state_dict[mm_state][vm_resource_state].append(vm_dict["image"])
-
-    total_scheduled = 0
-    rows = []
-    for mm_state in sorted(mm_state_dict.keys()):
-        for vm_resource_state in sorted(mm_state_dict[mm_state].keys()):
             if vm_resource_state == "None":
                 continue
-            os_set = set(mm_state_dict[mm_state][vm_resource_state])
-            for op_sys in sorted(os_set):
-                count = mm_state_dict[mm_state][vm_resource_state].count(op_sys)
-                total_scheduled += count
-                mm_state_str = mm_state
-                vm_resource_state_str = vm_resource_state
-                if "run" in mm_state.lower():
-                    mm_state_str = f"[green]{mm_state}"
-                if "error" in mm_state.lower():
-                    mm_state_str = f"[red]{mm_state}"
-                if "configuring" in vm_resource_state.lower():
-                    vm_resource_state_str = f"[yellow]{vm_resource_state}"
-                if "configured" in vm_resource_state.lower():
-                    vm_resource_state_str = f"[green]{vm_resource_state}"
-                if "uninitialized" in vm_resource_state.lower():
-                    vm_resource_state_str = f"[yellow]{vm_resource_state}"
-                if "error" in vm_resource_state.lower():
-                    vm_resource_state_str = f"[red]{vm_resource_state}"
-                rows.append([op_sys, mm_state_str, vm_resource_state_str, str(count)])
 
-    table = build_table(rows, total_scheduled)
-    return table
+            key = (image, mm_state, vm_resource_state)
+            grouped[key] = grouped.get(key, 0) + 1
+
+        for image, mm_state, vm_resource_state in sorted(grouped.keys()):
+            count = grouped[(image, mm_state, vm_resource_state)]
+            total_scheduled += count
+            rows.append(
+                {
+                    "vm_image": image,
+                    "power_state": mm_state,
+                    "vm_resource_state": vm_resource_state,
+                    "count": count,
+                }
+            )
+
+    return {
+        "experiment_active": active_exp_present,
+        "total_scheduled": total_scheduled,
+        "rows": rows,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
 
 
-def build_table(rows, total_scheduled):
+def style_power_state(mm_state):
     """
-    Construct a table given rows of VM information.
+    Add Rich styling to a minimega power state for table output.
 
     Args:
-        rows (list): A list of information per set of VMs (each list element
-            representing one row in the output VM mix table).
-        total_scheduled (int): The total number of VMs scheduled in the experiment.
+        mm_state (str): The raw power state.
 
     Returns:
-        firewheel.cli.utils.RichDefaultTable: A table giving the mix of VMs in the experiment.
+        str: The styled power state string.
+    """
+    if "run" in mm_state.lower():
+        return f"[green]{mm_state}"
+    if "error" in mm_state.lower():
+        return f"[red]{mm_state}"
+    if "pause" in mm_state.lower():
+        return f"[yellow]{mm_state}"
+    return mm_state
+
+
+def style_vm_resource_state(vm_resource_state):
+    """
+    Add Rich styling to a VM resource state for table output.
+
+    Args:
+        vm_resource_state (str): The raw VM resource state.
+
+    Returns:
+        str: The styled VM resource state string.
+    """
+    if "configuring" in vm_resource_state.lower():
+        return f"[yellow]{vm_resource_state}"
+    if "configured" in vm_resource_state.lower():
+        return f"[green]{vm_resource_state}"
+    if "uninitialized" in vm_resource_state.lower():
+        return f"[yellow]{vm_resource_state}"
+    if "error" in vm_resource_state.lower():
+        return f"[red]{vm_resource_state}"
+    return vm_resource_state
+
+
+def build_table(vm_mix_data):
+    """
+    Construct a rich table given structured VM mix data.
+
+    Args:
+        vm_mix_data (dict): Structured VM mix data.
+
+    Returns:
+        firewheel.cli.utils.RichDefaultTable: A table giving the mix of VMs
+            in the experiment.
     """
     table = RichDefaultTable(
         title="VM Mix",
@@ -119,24 +154,75 @@ def build_table(rows, total_scheduled):
     table.add_column("VM Image")
     table.add_column("Power State")
     table.add_column("VM Resource State", footer="[b]Total Scheduled")
-    table.add_column("Count", footer=f"[b]{total_scheduled}")
-    # Add custom rows to the table
-    if not rows:
-        rows.append(["N/A", "N/A", "N/A", "0"])
-    for row in rows:
-        table.add_row(*row)
+    table.add_column("Count", footer=f"[b]{vm_mix_data['total_scheduled']}")
+
+    if not vm_mix_data["rows"]:
+        vm_mix_data["rows"] = [
+            {
+                "vm_image": "N/A",
+                "power_state": "N/A",
+                "vm_resource_state": "N/A",
+                "count": 0,
+            }
+        ]
+    for row in vm_mix_data["rows"]:
+        table.add_row(
+            row["vm_image"],
+            style_power_state(row["power_state"]),
+            style_vm_resource_state(row["vm_resource_state"]),
+            str(row["count"]),
+        )
+
     return table
+
+
+def output_json(vm_mix_data):
+    """
+    Print the structured VM mix data as JSON.
+
+    Args:
+        vm_mix_data (dict): Structured VM mix data.
+    """
+    print(json.dumps(vm_mix_data, indent=2, sort_keys=False))
+
+
+def create_parser():
+    """
+    Create the argparse parser for the vm mix helper.
+
+    Returns:
+        argparse.ArgumentParser: Parser for CLI arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Show the mix of VM images for the current experiment.",
+        prog="firewheel vm mix",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format. Defaults to table.",
+    )
+    return parser
 
 
 def main():
     """
     Provide the primary update functionality for VM Mix.
     """
+    parser = create_parser()
+    args = parser.parse_args()
+
+    if args.format == "json":
+        vm_mix_data = collect_vm_mix_data()
+        output_json(vm_mix_data)
+        return
+
     console = Console()
-    with Live(vm_mix(), console=console, screen=False, refresh_per_second=1) as live:
+    with Live(build_table(collect_vm_mix_data()), console=console, screen=False, refresh_per_second=1) as live:
         while True:
             sleep(2)
-            live.update(vm_mix())
+            live.update(build_table(collect_vm_mix_data()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Refactor several FIREWHEEL CLI helpers to support structured machine-readable output for future MCP integration while preserving existing human-facing behavior by default.

This PR introduces a consistent output pattern across the updated helpers:
- explicit `--format ...` selection for human-readable vs machine-readable output
- structured internal data collection separated from rendering
- Rich-based human rendering where appropriate
- JSON output for machine consumers
- backward-compatible legacy flags retained where needed (for example `--csv` and `--json` aliases)

The helpers updated in this PR are:
- `vm mix`
- `status`
- `repository list`
- `mm show_caches`
- `push file`
- `pull file`
- `time`
- `experiment`
- `vm list`
- `vm log`
- `mc list`

In addition to helper code changes, the corresponding helper documentation was updated to describe the new output modes and retained compatibility flags.

### Motivation and context ###
This change is required to make FIREWHEEL CLI helpers easier to integrate into a future MCP server and other automation tooling.

Previously, many helpers only emitted human-oriented text, tables, or ad hoc output that was difficult to consume programmatically. Even helpers with some structured output support did not consistently follow a shared pattern. This PR addresses that by standardizing helper behavior around:
- collecting structured result data first
- rendering either human-readable output or JSON from that same data
- preserving default UX for existing users

A few notable design points:
- `vm list` now supports `--format table|json|csv` while retaining `--csv` for backward compatibility.
- `vm log` now separates output format from artifact selection via `--format {text,json}` and `--log-type {text,json}`, while retaining `--json` as a backward-compatible alias for the JSON log artifact.
- `experiment` now supports `--format table|json`, returns structured JSON summaries, and uses safer per-phase output capture for JSON mode to reduce interference from helper/runtime output. JSON mode currently requires `--no-install` to avoid interactive Model Component INSTALL prompting.
- `mc list` was refactored to return structured grouped data and now uses Rich for text rendering rather than `colorama`, eliminating the need for the old monochrome flag.

This PR is intentionally scoped to a single goal: establishing consistent machine-readable output support and documentation updates across the targeted CLI helpers.

## Type of Change ##
- New feature
- Documentation update
- Other: CLI refactor for consistent machine-readable output conventions and backward-compatible output modernization

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] A human has performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code with the functional test suite, and it passed.

## Additional Notes ##
This PR completes an initial helper refactor set for MCP-oriented integration.

A possible follow-on PR on `experiment` may include:
- A better method of not requiring the `--no-install` flag.

Backward compatibility notes:
- `vm list --csv` is retained as an alias for CSV output
- `time --json` is retained as an alias for JSON output
- `vm log --json` is retained as an alias for selecting the JSON log artifact

Potential reviewer focus areas:
- structured output schemas and naming consistency
- `experiment` JSON-mode capture behavior
- `vm log` multiline text log parsing and JSON log artifact handling
- documentation alignment with final helper behavior