### PR TITLE
feat: Allow configurable minimega base image

### DIFF
--- a/docker/firewheel.dockerfile
+++ b/docker/firewheel.dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/sandia-minimega/minimega:master AS minimega
+# To specify an alternate base image: --build-arg BASE_IMAGE="some/other/image:tag"
+ARG MINIMEGA_BASE_IMAGE="ghcr.io/sandia-minimega/minimega:master"
+FROM $MINIMEGA_BASE_IMAGE AS minimega
 
 # --#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#-- #
 


### PR DESCRIPTION
## Description

This MR updates the Dockerfile to allow the minimega base image to be overridden at build time using a build argument.

By default, the image remains:

`ghcr.io/sandia-minimega/minimega:master`

An alternate base image can now be specified with:

```bash
docker build --build-arg MINIMEGA_BASE_IMAGE="some/other/image:tag" .
```

This follows the pattern used by the [minimega](https://github.com/sandia-minimega/minimega/blob/96a5ea700b35cbaf6a2b99c8c4e7aa0f44e19117/docker/Dockerfile#L1) Dockerfile.
### Motivation and context ###

This change makes the build process more flexible by allowing developers or CI jobs to test against alternate minimega images without modifying the Dockerfile directly.

## Type of Change ##

- New feature

## Checklist ##

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] A human has performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] _N/A_ I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code with an equivalent Docker build workflow

## Additional Notes ##

This change preserves the existing default behavior while adding support for overriding the minimega base image via `MINIMEGA_BASE_IMAGE`.