### PR TITLE
fix: Correct file-server URL playbook variables

### DIFF
--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/url.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/url.yml
@@ -40,7 +40,7 @@
         loop_var: server
       vars:
         firewheel_url: "{{ server.url }}"
-        firewheel_cache_path: "{{ server.use_proxy }}"
+        firewheel_cache_path: "{{ server.cache_path }}"
         firewheel_validate_certs: "{{ server.validate_certs | default(true) }}"
         firewheel_use_proxy: "{{ server.use_proxy | default(true) }}"
 

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/url_pull_loop.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/url_pull_loop.yml
@@ -39,5 +39,5 @@
   rescue:
     - name: Handle download failures
       ansible.builtin.debug:
-        msg: "Pulling file from {{ firewheel_url }}/{{ firewheel_url_cache_path }} failed. Continuing..."
+        msg: "Pulling file from {{ firewheel_url }}/{{ firewheel_cache_path }} failed. Continuing..."
       when: url_download_result is failed


### PR DESCRIPTION
## Description

This MR fixes two variable reference bugs in the FIREWHEEL Ansible playbooks used for file-server URL-based installations.

The changes correct:

- `firewheel_cache_path` assignment in `url.yml` to use `server.cache_path` instead of `server.use_proxy`
- A debug message in `url_pull_loop.yml` to reference `firewheel_cache_path` instead of the undefined `firewheel_url_cache_path`

### Motivation and context ###

These fixes address issues where file-server installation tasks could use an incorrect cache path value or reference an undefined variable during download failure handling.

By correcting the variable names, the playbooks now use the intended cache path configuration and provide accurate failure messages when URL pulls fail.

## Type of Change ##

- Bugfix

## Checklist ##

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] A human has performed a self-review of my code.
- [ ] _N/A_ I have commented my code, particularly in hard-to-understand areas.
- [ ] _N/A_ I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have tested my code with the functional test suite, and it passed.

## Additional Notes ##

This MR only corrects variable references in the affected Ansible tasks and does not otherwise change file-server installation behavior.