### PR TITLE
build: Parameterize FIREWHEEL image config and install utilities repo

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 # FIREWHEEL Docker
 
 > [!WARNING]
-> This feature is currently in beta testing! Use at your own risk! 
+> This feature is currently in beta testing! Use at your own risk!
 
 > [!NOTE]
 > The FIREWHEEL docker container is based on the [minimega](https://github.com/sandia-minimega/minimega/) container image!
@@ -13,6 +13,7 @@ Follow the official installation instructions: [Install Docker Engine](https://d
 For development purposes, it maybe helpful to add your user to the `docker` group: `sudo usermod -aG docker $USER`
 
 ## Getting Started
+
 The easiest way to get started is to use the existing pre-built container provided by GitHub's container registry (found [here](https://github.com/sandialabs/firewheel/pkgs/container/firewheel/)).
 
 If building the image is necessary, than it must be built from the base directory of the FIREWHEEL repository.
@@ -21,7 +22,8 @@ If building the image is necessary, than it must be built from the base director
 docker build -t firewheel -f docker/firewheel.dockerfile .
 ```
 
-### Low-Trust Enviornments
+### Low-Trust Environments
+
 If the container is running in a low-trust environment (e.g., volumes cannot be mounted or additional software cannot be installed on the host) than the container will still run, but _likely_ lack the ability to launch VMs or connect together.
 Effectively, this breaks minimega, but still enables the user to design and code the topology.
 That is, building new model components and topologies is still possible as is checking for dependency issues, syntax errors, etc.
@@ -38,9 +40,10 @@ sudo docker run --rm -it ghcr.io/sandialabs/firewheel:main
 > In addition to the CPU model change, VMs must **NOT** have a network interface (as OVS will not work).
 
 ### High-Trust Environments
+
 To access the full range of capabilities (including launching VMs), this docker container needs various system privileges and mounted volumes.
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > Host Requirements:
 > * The host running the docker container must have Open vSwitch installed.
 > * The host running the docker container must have QEMU/KVM installed.
@@ -48,20 +51,24 @@ To access the full range of capabilities (including launching VMs), this docker 
 Once the prerequisites have been met, the FIREWHEEL container can be started via:
 
 ```bash
-sudo docker run --rm -it --privileged --cap-add ALL -v /dev:/dev -v /lib/modules:/lib/modules:ro ghcr.io/sandialabs/firewheel:main
+sudo docker run -it --rm --privileged --cap-add ALL \
+            --mount type=bind,source="/dev,target=/dev" \
+            --mount type=bind,source="/lib/modules,target=/lib/modules,readonly" \
+            ghcr.io/sandialabs/firewheel:main
 ```
 
 The additional privileges and system mounts (e.g. `/dev`) are required for the Open vSwitch process to run inside the container and to allow minimega to perform file injections.
 Optionally, users can add `-p 9001:9001` to expose the [miniweb](https://sandialabs.github.io/firewheel/tutorials/router_tree.html#using-miniweb) port to the host system for easy access.
 
 ## Docker Environment
+
 Once the container is launched, it will kick off a script which ensures that a new FIREWHEEL environment is ready to go and "drop" the user into a new [tmux](https://github.com/tmux/tmux/wiki) session.
 
 > [!NOTE]
 > The tmux default prefix key is `C-a`, which means the <kbd>Ctrl</kbd> key and <kbd>a</kbd> (e.g., <kbd>Ctrl</kbd>+<kbd>a</kbd>).
 
 Users will need to install any extra images or load any new model components that need to be placed into the environment.
-It is also possible to mount a new volume with those pre-loaded model components, for example `-v /opt/firewheel/model_components:/models`.
+It is also possible to mount a new volume with those pre-loaded model components, for example, by appending the option `--mount type=bind,source="/opt/firewheel/model_components,target=/models"`.
 Then once the environment is started, simply add that path as a new model component repository (e.g., `firewheel repository install /models`).
 
 ## FIREWHEEL, minimega, and miniweb configuration
@@ -72,32 +79,36 @@ Rather than describing them here, we refer to the following places:
 * minimega settings are provided in both [start-minimega.sh](./start-minimega.sh) and [minimega](./fsroot/etc/default/minimega).
 * miniweb settings are provided in both [start-minimega.sh](./start-minimega.sh).
 
-Currently, the pre-built FIREWHEEL container contains several hard-coded options to work for *most* users.
-The minimega configuration values can be overwritten either by passing environment variables to Docker when starting the container or by binding a file to `/etc/default/minimega` in the container that contains updated values.
+The pre-built FIREWHEEL container accepts arguments to customize builds, with unset arguments defaulting to sensible defaults (the FIREWHEEL team's recommended settings).
 
-Users can also add an additional layer to the docker container to help adjust these values as needed (see: [docker build variables](https://docs.docker.com/build/building/variables)).
-An example of how to do this is shown below:
+These arguments allow a container to be built with:
+1. A custom base image:
+   ```bash
+   docker build --build-arg MINIMEGA_BASE_IMAGE="custom-image:latest" \
+                -t firewheel -f docker/firewheel.dockerfile .
+   ```
+2. Minimega environment variable settings (e.g, `MM_BASE`, `MM_FILEPATH`, etc.):
+   ```bash
+   docker build --build-arg BUILD_MM_BASE="/scratch/minimega" \
+                -t firewheel -f docker/firewheel.dockerfile .
+   ```
+3. A subset of [environment variables used by FIREWHEEL's `install.sh` script](https://sandialabs.github.io/firewheel/install/install.html) (e.g,. `DEFAULT_OUTPUT_DIR`, `GRPC_HOSTNAME`, `EXPERIMENT_INTERFACE`, etc.): 
+   ```bash
+   docker build --build-arg BUILD_DEFAULT_OUTPUT_DIR="/scratch"
+                -t firewheel -f docker/firewheel.dockerfile .
+   ```
 
-```docker
-# This new container enables users to build the container
-# with an alternative minimega files path
-FROM ghcr.io/sandialabs/firewheel:main AS firewheel
+Note that in the case of environment variables that will be passed through to the FIREWHEEL environment and scripts, the corresponding build argument on the command line is given using the `BUILD_` prefix.
 
-# Take in an optional build argument
-ARG MM_FILEPATH=/tmp/minimega/files
-
-RUN echo -e "\nMM_FILEPATH=${MM_FILEPATH}" >> /etc/default/minimega
-
-RUN bash -c "source /fwpy/bin/activate  && \
-    mkdir -p ${MM_FILEPATH} \
-    firewheel config set -s minimega.files_dir ${MM_FILEPATH}"
-```
+For more information, see the documentation for [Docker build variables](https://docs.docker.com/build/building/variables).
 
 ## Technical Details
+
 As with most docker containers, the default user is `root`.
 However, we have also created a separate `firewheel` user that has a large `uid` and can be used in low-trust environments where a root user may not be permitted.
 
 ### Default Program Changes
+
 To enable FIREWHEEL to work properly (without any modifications) the docker based implementation needed to avoid some FIREWHEEL/minimega required packages.
 These include:
 - `sudo` - and specifically `sudo systemctl`
@@ -108,6 +119,7 @@ However, the original programs have been kept/renamed to `<progname>-old` (e.g.,
 Therefore, if these programs are needed, they are still available, but will not be used by FIREWHEEL.
 
 ### Minimega Differences
+
 The minimega container provides a [`start-minimega.sh`](https://github.com/sandia-minimega/minimega/blob/master/docker/start-minimega.sh) script which is overwritten by a customized version in the FIREWHEEL container.
 The primary difference between these scripts is the addition of logging various errors and exiting early if minimega is already running.
 

--- a/docker/firewheel.dockerfile
+++ b/docker/firewheel.dockerfile
@@ -5,26 +5,46 @@ FROM $MINIMEGA_BASE_IMAGE AS minimega
 # --#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#-- #
 
 ## User Arguments
-ARG USER=firewheel
-ARG USER_UID=1001750000
+ARG BUILD_USER=firewheel
+ARG BUILD_USER_UID=1001750000
 
 ## Minimega Arguments
-ARG MM_BASE=/tmp/minimega
-ARG MM_RUN_PATH=/tmp/minimega
-ARG MM_FILEPATH=/tmp/minimega/files
-ARG MM_PORT=9000
-ARG MM_DEGREE=1
-ARG MM_CONTEXT=firewheel
-ARG MM_FORCE=true
-ARG MM_LOGLEVEL=debug
-ARG MM_LOGFILE=/var/log/minimega.log
+ARG BUILD_MM_BASE=/tmp/minimega
+ARG BUILD_MM_RUN_PATH=/tmp/minimega
+ARG BUILD_MM_FILEPATH=/tmp/minimega/files
+ARG BUILD_MM_PORT=9000
+ARG BUILD_MM_DEGREE=1
+ARG BUILD_MM_CONTEXT=firewheel
+ARG BUILD_MM_FORCE=true
+ARG BUILD_MM_LOGLEVEL=debug
+ARG BUILD_MM_LOGFILE=/var/log/minimega.log
 
 ## FIREWHEEL Arguments
-ARG GRPC_HOSTNAME=localhost
-ARG EXPERIMENT_INTERFACE=lo
-ARG OUTPUT_DIR=/scratch/firewheel
-ARG LOGGING_ROOT_DIR=/scratch/firewheel
-ARG FW_PACKAGE_SRC=firewheel
+ARG BUILD_GRPC_HOSTNAME=localhost
+ARG BUILD_EXPERIMENT_INTERFACE=lo
+ARG BUILD_OUTPUT_DIR=/scratch/firewheel
+ARG BUILD_LOGGING_ROOT_DIR=/scratch/firewheel
+ARG BUILD_FW_PACKAGE_SRC=firewheel
+
+
+# --#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#-- #
+
+ENV USER=${BUILD_USER} \
+    USER_UID=${BUILD_USER_UID} \
+    MM_BASE=${BUILD_MM_BASE} \
+    MM_RUN_PATH=${BUILD_MM_RUN_PATH} \
+    MM_FILEPATH=${BUILD_MM_FILEPATH} \
+    MM_PORT=${BUILD_MM_PORT} \
+    MM_DEGREE=${BUILD_MM_DEGREE} \
+    MM_CONTEXT=${BUILD_MM_CONTEXT} \
+    MM_FORCE=${BUILD_MM_FORCE} \
+    MM_LOGLEVEL=${BUILD_MM_LOGLEVEL} \
+    MM_LOGFILE=${BUILD_MM_LOGFILE} \
+    GRPC_HOSTNAME=${BUILD_GRPC_HOSTNAME} \
+    EXPERIMENT_INTERFACE=${BUILD_EXPERIMENT_INTERFACE} \
+    OUTPUT_DIR=${BUILD_OUTPUT_DIR} \
+    LOGGING_ROOT_DIR=${BUILD_LOGGING_ROOT_DIR} \
+    FW_PACKAGE_SRC=${BUILD_FW_PACKAGE_SRC}
 
 # --#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#--#-- #
 
@@ -77,27 +97,27 @@ RUN bash -c "python3.10 -m venv /fwpy \
 
 # Configure Firewheel
 RUN bash -c "source /fwpy/bin/activate  && \
-    mkdir -p ${LOGGING_ROOT_DIR} && \
-    mkdir -p ${MM_FILEPATH} && \
-    mkdir -p ${OUTPUT_DIR} && \
-    mkdir -p ${OUTPUT_DIR}/vm_resource_logs && \
-    mkdir -p ${OUTPUT_DIR}/transfers && \
-    firewheel config set -s system.default_group ${USER} && \
-    firewheel config set -s minimega.experiment_interface ${EXPERIMENT_INTERFACE} && \
-    firewheel config set -s system.default_output_dir ${OUTPUT_DIR} && \
-    firewheel config set -s minimega.base_dir ${MM_BASE} && \
-    firewheel config set -s minimega.files_dir ${MM_FILEPATH} && \
+    mkdir -p \"${LOGGING_ROOT_DIR}\" && \
+    mkdir -p \"${MM_FILEPATH}\" && \
+    mkdir -p \"${OUTPUT_DIR}\" && \
+    mkdir -p \"${OUTPUT_DIR}/vm_resource_logs\" && \
+    mkdir -p \"${OUTPUT_DIR}/transfers\" && \
+    firewheel config set -s system.default_group \"${USER}\" && \
+    firewheel config set -s minimega.experiment_interface \"${EXPERIMENT_INTERFACE}\" && \
+    firewheel config set -s system.default_output_dir \"${OUTPUT_DIR}\" && \
+    firewheel config set -s minimega.base_dir \"${MM_BASE}\" && \
+    firewheel config set -s minimega.files_dir \"${MM_FILEPATH}\" && \
     firewheel config set -s python.venv /fwpy && \
     firewheel config set -s python.bin python3 && \
-    firewheel config set -s grpc.hostname ${GRPC_HOSTNAME} && \
-    firewheel config set -s logging.root_dir ${LOGGING_ROOT_DIR}" \
+    firewheel config set -s grpc.hostname \"${GRPC_HOSTNAME}\" && \
+    firewheel config set -s logging.root_dir \"${LOGGING_ROOT_DIR}\"" \
     || { echo "Firewheel configuration failed"; exit 1; }
 
 # Set up Bash completion
 RUN bash -c "source /fwpy/bin/activate  && \
     prep_fw_tab_completion && \
     echo 'source \$(/fwpy/bin/prep_fw_tab_completion --print-path)' >> /root/.bashrc && \
-    echo 'source \$(/fwpy/bin/prep_fw_tab_completion --print-path)' >> /home/$USER/.bashrc" \
+    echo 'source \$(/fwpy/bin/prep_fw_tab_completion --print-path)' >> \"/home/$USER/.bashrc\"" \
     || { echo "Bash completion setup failed"; exit 1; } 
 
 
@@ -120,6 +140,6 @@ RUN chmod +x /usr/local/bin/entry && \
 # Change ownership of all files in the container to the new user
 # Note: This should be done after all files are copied to the image
 # (e.g., after COPY or ADD commands)
-RUN chown -R $USER_UID:$USER_UID /fwpy /start-minimega.sh /tmp /scratch /var/log /opt
+RUN chown -R "$USER_UID:$USER_UID" /fwpy /start-minimega.sh /tmp /scratch /var/log /opt
 
 ENTRYPOINT ["/usr/local/bin/entry"]

--- a/docker/firewheel.dockerfile
+++ b/docker/firewheel.dockerfile
@@ -22,7 +22,7 @@ ARG BUILD_MM_LOGFILE=/var/log/minimega.log
 ## FIREWHEEL Arguments
 ARG BUILD_GRPC_HOSTNAME=localhost
 ARG BUILD_EXPERIMENT_INTERFACE=lo
-ARG BUILD_OUTPUT_DIR=/scratch/firewheel
+ARG BUILD_DEFAULT_OUTPUT_DIR=/scratch/firewheel
 ARG BUILD_LOGGING_ROOT_DIR=/scratch/firewheel
 ARG BUILD_FW_PACKAGE_SRC=firewheel
 
@@ -42,7 +42,7 @@ ENV USER=${BUILD_USER} \
     MM_LOGFILE=${BUILD_MM_LOGFILE} \
     GRPC_HOSTNAME=${BUILD_GRPC_HOSTNAME} \
     EXPERIMENT_INTERFACE=${BUILD_EXPERIMENT_INTERFACE} \
-    OUTPUT_DIR=${BUILD_OUTPUT_DIR} \
+    DEFAULT_OUTPUT_DIR=${BUILD_DEFAULT_OUTPUT_DIR} \
     LOGGING_ROOT_DIR=${BUILD_LOGGING_ROOT_DIR} \
     FW_PACKAGE_SRC=${BUILD_FW_PACKAGE_SRC}
 
@@ -106,12 +106,12 @@ RUN bash -c "python3.10 -m venv /fwpy \
 RUN bash -c "source /fwpy/bin/activate  && \
     mkdir -p \"${LOGGING_ROOT_DIR}\" && \
     mkdir -p \"${MM_FILEPATH}\" && \
-    mkdir -p \"${OUTPUT_DIR}\" && \
-    mkdir -p \"${OUTPUT_DIR}/vm_resource_logs\" && \
-    mkdir -p \"${OUTPUT_DIR}/transfers\" && \
+    mkdir -p \"${DEFAULT_OUTPUT_DIR}\" && \
+    mkdir -p \"${DEFAULT_OUTPUT_DIR}/vm_resource_logs\" && \
+    mkdir -p \"${DEFAULT_OUTPUT_DIR}/transfers\" && \
     firewheel config set -s system.default_group \"${USER}\" && \
     firewheel config set -s minimega.experiment_interface \"${EXPERIMENT_INTERFACE}\" && \
-    firewheel config set -s system.default_output_dir \"${OUTPUT_DIR}\" && \
+    firewheel config set -s system.default_output_dir \"${DEFAULT_OUTPUT_DIR}\" && \
     firewheel config set -s minimega.base_dir \"${MM_BASE}\" && \
     firewheel config set -s minimega.files_dir \"${MM_FILEPATH}\" && \
     firewheel config set -s python.venv /fwpy && \

--- a/docker/firewheel.dockerfile
+++ b/docker/firewheel.dockerfile
@@ -91,7 +91,14 @@ RUN bash -c "python3.10 -m venv /fwpy \
     && source /fwpy/bin/activate \
     && python3 -m pip install --upgrade wheel setuptools pip \
     && python3 -m pip install --upgrade ${FW_PACKAGE_SRC} \
-    && python3 -m pip install --upgrade firewheel-repo-base firewheel-repo-linux firewheel-repo-vyos firewheel-repo-layer2 firewheel-repo-tutorials firewheel-repo-dns firewheel-repo-ntp \
+    && python3 -m pip install --upgrade firewheel-repo-base \
+                                        firewheel-repo-linux \
+                                        firewheel-repo-vyos \
+                                        firewheel-repo-layer2 \
+                                        firewheel-repo-tutorials \
+                                        firewheel-repo-dns \
+                                        firewheel-repo-ntp \
+                                        firewheel-repo-utilities \
     && ln -s /fwpy/bin/firewheel /usr/local/bin/firewheel" \
     || { echo "Firewheel installation failed"; exit 1; }
 


### PR DESCRIPTION
## Description

This MR updates the FIREWHEEL Docker image build configuration to use build-time arguments that are promoted into environment variables, and adds the `firewheel-repo-utilities` package to the set of repositories installed in the image.

The Dockerfile now:

- Renames build arguments with a `BUILD_` prefix.
- Exposes the corresponding runtime values through `ENV`.
- Standardizes environment variables with the `install.sh` script
  - This provides uniformity through the codebase, but it also allows the Docker README to point to the section of the hosted docs describing available installation environment variables.
- Uses those environment variables consistently in FIREWHEEL and minimega configuration commands.
- Quotes variable expansions in Dockerfile shell commands to make path and value handling safer.
- Installs `firewheel-repo-utilities` alongside the existing FIREWHEEL repository packages.
- Prefers the newer `--mount type=bind,source=..."` syntax to the `-v` option for mounting directories.

### Motivation and context ###

The Docker image previously relied directly on Docker build arguments for values used during configuration. Since `ARG` values are only available at build time, promoting these values into `ENV` makes the resulting image configuration clearer and allows the same values to be available to later Dockerfile commands and at runtime.

This change also includes `firewheel-repo-utilities` in the default image installation so that utility repository functionality is available without requiring users to install it manually after building or starting the container.

## Type of Change ##

- Other: Docker image build/configuration and dependency update

## Checklist ##

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] A human has performed a self-review of my code.
- [ ] _N/A_ I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] _N/A_ I have tested my code with the functional test suite, and it passed.

## Additional Notes ##

This MR is limited to Docker image configuration and package installation changes. No FIREWHEEL application logic is modified.