### PR TITLE
feat(model component install): support cached install inputs for offline model component setup

### DIFF
--- a/docs/source/system/model_component/mc_install.rst
+++ b/docs/source/system/model_component/mc_install.rst
@@ -4,9 +4,9 @@
 Model Component INSTALL file
 ############################
 
-Some Model Components may require additional Python packages to be installed within FIREWHEEL's virtual environment or for data to be downloaded.
-In this case, the Model Component can have an ``INSTALL`` directory, which contains a valid `Ansible Playbook <https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_intro.html>`_ (recommended method).
-Alternatively, ``INSTALL`` can be an executable script (as denoted by a `shebang <https://en.wikipedia.org/wiki/Shebang_(Unix)>`_ line), though this is not recommended and support will be removed in a future releases.
+Some model components may require additional Python packages to be installed within FIREWHEEL's virtual environment or for data to be downloaded.
+In this case, the model component can have an ``INSTALL`` directory, which contains a valid `Ansible Playbook <https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_intro.html>`_ (recommended method).
+Alternatively, ``INSTALL`` can be an executable script (as denoted by a `shebang <https://en.wikipedia.org/wiki/Shebang_(Unix)>`_ line), though this is not recommended and support will be removed in a future release.
 When users use the :ref:`helper_mc_generate` Helper, a new INSTALL directory is created with sample ``tasks.yml`` and ``vars.yml`` automatically included.
 
 
@@ -19,8 +19,8 @@ Design Principles
 
 We recommend that the following principles are adhered to when installing a model component.
 
-1. `Idempotence <https://en.wikipedia.org/wiki/Idempotence>`_ -- The file(s) should be capable of running multiple times without causing issues. This is a core tenant of Ansible and a strong motivator why Ansible playbooks are the preferred method.
-2. **Reproducibility** -- It is critical that users download the exact same data that was originally intended by the Model Component creators.
+1. `Idempotence <https://en.wikipedia.org/wiki/Idempotence>`_ -- The file(s) should be capable of running multiple times without causing issues. This is a core tenet of Ansible and a strong motivator why Ansible playbooks are the preferred method.
+2. **Reproducibility** -- It is critical that users download the exact same data that was originally intended by the model component creators.
    If the data/packages differ, then there is a strong possibility that the experimental outcomes will differ and could produce unintended consequences.
    Therefore, we strongly recommend that MC creators link to exact versions of software to download, rather than an automatically updating link.
    For example, if the MC was supposed to install a GitLab runner:
@@ -33,7 +33,7 @@ We recommend that the following principles are adhered to when installing a mode
         # GOOD: Get version 11.4.2
         wget https://s3.amazonaws.com/gitlab-runner-downloads/v11.4.2/binaries/gitlab-runner-linux-386
 
-3. **Integrity** -- A checksum for all downloaded files is strongly recommend both to facilitate reproducibility and to increase the security of the experiment.
+3. **Integrity** -- A checksum for all downloaded files is strongly recommended both to facilitate reproducibility and to increase the security of the experiment.
 4. **Offline Accessible** -- Many experiments are conducted on infrastructure that lacks Internet access. Therefore, we recommend that INSTALL files allow users to achieve the same end result using cached files.
 5. **Cleanup** -- Only the essential dependencies should be kept and any irrelevant data that may have been generated during intermediate steps should be removed.
 6. **Readability** -- Users will need to execute these potentially unknown actions, the INSTALL script should be well documented and readable to the average user. Readability is desired over brevity.
@@ -97,14 +97,28 @@ The tasks file should be a YAML list with any tasks needed to ensure that the mo
 The ``vars.yml`` file should be a YAML dictionary of all the variable keys/values which will be used when installing the model component.
 FIREWHEEL will automatically provide the following variables to the Ansible playbooks when running:
 
-- ``mc_name`` -- The name of the Model Component.
+- ``mc_name`` -- The name of the model component.
 - ``mc_dir`` -- The full path to the model component directory.
 
 In addition to any variables the specific tasks need, the ``vars.yml`` *should* have a ``required_files`` key where a list of the final output files is listed.
-This is because the model component installation is assumed to be complete when all ``required_files`` are present.
-As an added benefit, FIREWHEEL supports caching pre-computed blobs from various resources to enable offline experiment access and the ``required_files`` supports this feature.
-The process of collecting offline required files is automatically handled by FIREWHEEL and using this process is discussed in detail in :ref:`mc_install_cache`.
-If no ``required_files`` are needed, then it can be omitted from ``INSTALL/vars.yml``.
+This is because the model component installation is assumed to be complete when all ``required_files`` are present and, if checksums are provided, valid.
+
+Some installations also need intermediate input files, such as archives, installers, datasets, or other blobs, that are not themselves the final installed state.
+For these cases, ``vars.yml`` may also define an ``install_inputs`` key.
+The ``install_inputs`` list describes cacheable files that FIREWHEEL may retrieve before running ``tasks.yml``.
+Unlike ``required_files``, ``install_inputs`` do **not** indicate that installation is complete.
+Instead, ``tasks.yml`` is responsible for consuming those inputs and producing the final files listed in ``required_files``.
+
+As an added benefit, FIREWHEEL supports caching pre-computed blobs from various resources to enable offline experiment access.
+Both ``required_files`` and ``install_inputs`` support this cache retrieval process.
+The distinction is:
+
+- ``required_files`` -- Final installed files. If all are present and valid, the model component is considered installed.
+- ``install_inputs`` -- Cacheable inputs used by ``tasks.yml`` to produce the final installed files. These are not completion markers.
+
+If no final output files need to be tracked, then ``required_files`` can be omitted from ``INSTALL/vars.yml``.
+However, model components that define ``install_inputs`` should normally also define ``required_files`` so FIREWHEEL can verify that ``tasks.yml`` successfully processed those inputs into the desired final state.
+If no intermediate cacheable inputs are needed, then ``install_inputs`` can be omitted.
 
 Continuing the example from above, the end result of ``tasks.yml`` is the creation of the file ``{{ mc_dir }}/vm_resources/debs/htop-1_0_2_debs.tgz``.
 Therefore, this file is *required* to exist for the model component to be completely installed.
@@ -116,6 +130,25 @@ The ``vars.yml`` file would look like:
   required_files:
     - destination: "{{ mc_dir }}/vm_resources/debs/htop-1_0_2_debs.tgz"
 
+Some model components need a cached input artifact that must be processed before the final installed files exist.
+For example, a model component may use a cached archive and extract it into the final installation layout:
+
+.. code-block:: yaml
+  :caption: This is an example ``vars.yml`` file that uses an install input archive to create final required files.
+
+  install_inputs:
+    - destination: "{{ mc_dir }}/artifacts/example-data.tgz"
+      source: "{{ mc_name }}/example-data.tgz"
+      checksum_algorithm: "sha256"
+      checksum: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+  required_files:
+    - destination: "{{ mc_dir }}/vm_resources/example-data/metadata.json"
+    - destination: "{{ mc_dir }}/vm_resources/example-data/data.bin"
+
+In this example, FIREWHEEL may retrieve ``example-data.tgz`` from cache before running ``tasks.yml``.
+The ``tasks.yml`` file is then responsible for extracting that archive and creating the final files listed in ``required_files``.
+The model component is not considered installed merely because ``example-data.tgz`` exists.
 
 The full definition for ``required_files`` is:
 
@@ -130,12 +163,12 @@ The full definition for ``required_files`` is:
 .. confval:: source
 
     Where the file should be located **within** the cache.
-    This should not be set by MC creators, as it defaults to ``{{ mc_name }}/file``.
-    However, it is available to be modified by end-users if desired.
+    This defaults to ``{{ mc_name }}/{{ item.destination | basename }}``.
+    Model component creators or end-users may set this when the cache path should differ from the destination basename.
 
     :type: string
     :required: false
-    :default: ``{{ mc_name }}/file``
+    :default: ``{{ mc_name }}/{{ item.destination | basename }}``
 
 .. confval:: checksum_algorithm
 
@@ -157,33 +190,79 @@ The full definition for ``required_files`` is:
     :type: string
     :required: false
 
+The full definition for ``install_inputs`` is the same as ``required_files``:
+
+.. confval:: destination
+
+    Where the install input should be placed before ``tasks.yml`` runs.
+    Should include ``{{ mc_dir }}`` if the file needs to be relative to the model component directory.
+
+    :type: string
+    :required: true
+
+.. confval:: source
+
+    Where the file should be located **within** the cache.
+    This defaults to ``{{ mc_name }}/{{ item.destination | basename }}``.
+    Model component creators or end-users may set this when the cache path should differ from the destination basename.
+
+    :type: string
+    :required: false
+    :default: ``{{ mc_name }}/{{ item.destination | basename }}``
+
+.. confval:: checksum_algorithm
+
+    Algorithm to determine checksum of the input file.
+    Must be supported by `ansible.builtin.stat <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/stat_module.html#parameter-checksum_algorithm>`_ (e.g., ``"sha1"``, ``"sha256"``, etc.).
+
+    :type: string
+    :required: false
+
+.. confval:: checksum
+
+    The hash of the input file.
+
+    :type: string
+    :required: false
+
+.. note::
+
+    ``install_inputs`` are useful for offline installs where a cached artifact must be unpacked or transformed before the final installed files exist.
+    FIREWHEEL will attempt to retrieve ``install_inputs`` from configured caches, but will not use them as installation completion markers.
+    The final completion check is based on ``required_files``.
+    If a system is offline but all declared ``install_inputs`` are available and valid, FIREWHEEL may still run ``tasks.yml`` so the model component can produce its final ``required_files`` without Internet access.
+
 .. _mc_install_cache:
 
 ***************************
 Setting up an Offline Cache
 ***************************
 
-Collecting and retrieving files from a cache is automatically supported in Ansible playbooks without MC designer intervention.
+Collecting and retrieving files from a cache is automatically supported in Ansible playbooks without model component designer intervention.
 Currently, FIREWHEEL supports caching files in a file server, git repository, or in an Amazon S3 data store.
-If the user sets the necessary settings in the :ref:`firewheel_configuration` for the described types below, then FIREWHEEL will automatically check those locations for any model component ``required_files``.
-Users are able to set multiple cache types as FIREWHEEL will check any caches for the required file.
+If the user sets the necessary settings in the :ref:`firewheel_configuration` for the cache types described below, then FIREWHEEL will automatically check those locations for model component cacheable files.
+
+FIREWHEEL supports caching two categories of files:
+
+- ``required_files`` -- Final installed files. If these are retrieved from cache and validated, the model component may already be considered installed.
+- ``install_inputs`` -- Intermediate input files used by ``tasks.yml``. These may be retrieved from cache, but ``tasks.yml`` must still run to convert them into the final ``required_files``.
 
 Users setting up a cache should place cached files using the path: ``{{ mc_name }}/{{ item.destination | basename }}``.
 From the example above, the default ``source`` path would be ``linux.ubuntu/htop-1_0_2_debs.tgz``, where ``linux.ubuntu`` is the name of the associated model component.
-Users can optionally modify this path by setting the :confval:`source` within the model component variables file.
+Users can optionally modify this path by setting the :confval:`source` field within the relevant ``required_files`` or ``install_inputs`` entry.
 
 Git Cache
 =========
 Users can use `git <https://git-scm.com>`__ repositories for caching model component binaries.
 To use this, users will need to install  `git <https://git-scm.com>`__ and `git-lfs <https://git-lfs.com>`__ on their :ref:`cluster-control-node` to appropriately clone their repositories.
 This caching mechanism is set up so that repositories are initially cloned *without* downloading any large file storage (LFS) for performance reasons.
-Then if a ``required_file`` is identified without that repository, the file is subsequently downloaded and moved into place.
+Then, if a cacheable file from ``required_files`` or ``install_inputs`` is found in one of those repositories, the file is subsequently downloaded and moved into place.
 
 .. note::
 
   Users may also need to execute ``git lfs install`` to set up Git LFS for their user account.
 
-If users plan to use git repositories for the Model Component cache, they should specify the following options in the :ref:`firewheel_configuration` under the ``ansible`` key.
+If users plan to use git repositories for the model component cache, they should specify the following options in the :ref:`firewheel_configuration` under the ``ansible`` key.
 
 An example of this configuration is shown below:
 
@@ -255,7 +334,7 @@ S3 Cache
 ========
 Users can use `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__ buckets for caching model component binaries.
 To use this, users will need to install  `boto3 <https://pypi.org/project/boto3/>`__, the official Amazon Web Services (AWS) Software Development Kit (SDK) for Python into their FIREWHEEL virtual environment.
-Additionally, if users plan to use an AWS S3 instance for the Model Component cache, they should specify the following options in the :ref:`firewheel_configuration` under the ``ansible`` key.
+Additionally, if users plan to use an AWS S3 instance for the model component cache, they should specify the following options in the :ref:`firewheel_configuration` under the ``ansible`` key.
 
 An example of this configuration is shown below:
 
@@ -307,7 +386,7 @@ An example of this configuration is shown below:
         :type: string
         :required: true
 
-    .. confval:: s3_buckets
+    .. confval:: buckets
 
         A list of buckets associated with the S3 server where each bucket is represented as a string.
 
@@ -317,6 +396,45 @@ An example of this configuration is shown below:
 File Server Cache
 =================
 If users plan to use a file server (HTTP/HTTPS/FTP) for the Model Component cache, they can specify the following options in the :ref:`firewheel_configuration` under the ``ansible`` key.
+The file server cache uses Ansible's `ansible.builtin.get_url <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html>`_ module.
+The supported URL schemes are those supported by ``get_url`` for downloading files, primarily:
+
+- ``http://``
+- ``https://``
+- ``ftp://``
+
+A local filesystem path such as ``/path/to/cache`` is **not** itself a file server URL.
+If cached files already exist on disk and users want to use the file server cache mechanism, the directory should be served through one of the supported URL schemes, such as HTTP.
+For example, a user can expose a local cache directory with Python's built-in HTTP server:
+
+.. code-block:: bash
+
+   cd /path/to/firewheel-cache
+   python3 -m http.server 8000
+
+Then configure FIREWHEEL to use that local server:
+
+.. code-block:: yaml
+  :caption: Example file server cache configuration using a local on-disk cache served over HTTP.
+
+  ansible:
+    file_servers:
+      - url: "http://127.0.0.1:8000"
+        cache_paths:
+          - ""
+
+With this configuration, a cached file whose ``source`` is ``test.base_objects/MyTarball.tgz`` should be available at:
+
+.. code-block:: text
+
+   http://127.0.0.1:8000/test.base_objects/MyTarball.tgz
+
+If the cache root is served from a subdirectory, place that subdirectory in ``cache_paths`` instead.
+
+.. note::
+
+   The file server cache is intended for URL-based retrieval using protocols such as HTTP, HTTPS, and FTP.
+   For local on-disk caches, the recommended approach is to serve the cache directory over HTTP, rather than using a raw filesystem path or relying on ``file://`` behavior.
 
 An example of this configuration is shown below:
 
@@ -354,14 +472,29 @@ An example of this configuration is shown below:
 
         .. note::
 
-            If you are using an username or password token, you can specify it in the URL.
+            If you are using a username or password token, you can specify it in the URL.
             For example: ``https://user:password@server.com``
 
 
     .. confval:: cache_paths
 
-        A list of intermediate paths to the FIREWHEEL cache. For example in the URL ``http://example.com/files/firewheel/firewheel_repo_linux/linux.ubuntu/htop-1_0_2_debs.tgz`` then ``url="http://example.com"``,  ``url_cache_path="files/firewheel/firewheel_repo_linux"``, and the ``source=linux.ubuntu/htop-1_0_2_debs.tgz``.
-        If no cache path is required, please use a list with empty string entry as the value.
+        A list of intermediate paths to the FIREWHEEL cache.
+
+        For example, given this cached file URL:
+
+        .. code-block:: text
+
+          http://example.com/files/firewheel/firewheel_repo_linux/linux.ubuntu/htop-1_0_2_debs.tgz
+
+        the configuration would be:
+
+        .. code-block:: text
+
+          url = http://example.com
+          cache_path = files/firewheel/firewheel_repo_linux
+          source = linux.ubuntu/htop-1_0_2_debs.tgz
+
+        The ``source`` value comes from the relevant ``required_files`` or ``install_inputs`` entry.
 
         .. code-block:: yaml
 
@@ -369,6 +502,16 @@ An example of this configuration is shown below:
             - url: "http://example.com"
               cache_paths:
                 - ""
+
+        For a local cache served from a parent directory, include the relative cache directory as the cache path.
+        For example, if ``http://127.0.0.1:8000/firewheel-cache`` is the cache root, use:
+
+        .. code-block:: yaml
+
+          file_servers:
+            - url: "http://127.0.0.1:8000"
+              cache_paths:
+                - "firewheel-cache"
 
         :type: list
         :required: true
@@ -398,9 +541,9 @@ Script INSTALL File Requirements
 
   This method is **NOT** recommended and will be eliminated in future releases of FIREWHEEL.
 
-If the model component needs to use a single executable to install additional Model Component, users must create a single file called: ``INSTALL`` that should not have an extension and contains a `shebang <https://en.wikipedia.org/wiki/Shebang_(Unix)>`_ line (e.g., ``#!/bin/bash``).
+If the model component needs to use a single executable to install additional dependencies, users must create a single file called: ``INSTALL`` that should not have an extension and contains a `shebang <https://en.wikipedia.org/wiki/Shebang_(Unix)>`_ line (e.g., ``#!/bin/bash``).
 Additionally, users must ensure that, upon successful installation, a new file is created in the model component directory with the following format: ``.<MC Name>.installed``.
-For example, if the model component name is ``dns.dns_objects`` than the new file would be ``.dns.dns_objects.installed``.
+For example, if the model component name is ``dns.dns_objects`` then the new file would be ``.dns.dns_objects.installed``.
 
 .. dropdown:: A Bash-based INSTALL template
 
@@ -511,7 +654,7 @@ For example, if the model component name is ``dns.dns_objects`` than the new fil
         # (URL SHASUM-256 FILENAME).
         #
         # We recommend that explicit versions are used for all Images/VMRs to prevent
-        # possible differences between instances of a given Model Component.
+        # possible differences between instances of a given model component.
         # Please be mindful of the software versions as it can have unintended
         # consequences on your Emulytics experiment.
         #

--- a/docs/source/system/model_component/mc_install.rst
+++ b/docs/source/system/model_component/mc_install.rst
@@ -500,6 +500,7 @@ An example of this configuration is shown below:
 
           file_servers:
             - url: "http://example.com"
+              use_proxy: false
               cache_paths:
                 - ""
 
@@ -510,6 +511,7 @@ An example of this configuration is shown below:
 
           file_servers:
             - url: "http://127.0.0.1:8000"
+              use_proxy: false
               cache_paths:
                 - "firewheel-cache"
 

--- a/src/firewheel/control/ansible_playbooks/main.yml
+++ b/src/firewheel/control/ansible_playbooks/main.yml
@@ -11,10 +11,14 @@
 #
 #   The playbook performs the following steps:
 #   1. Imports variables from the specified model component.
-#   2. Attempts to retrieve required files from cache using the 'firewheel' role.
+#   2. Attempts to retrieve cacheable files from cache. This includes:
+#      - required_files: final installed files
+#      - install_inputs: inputs consumed by INSTALL/tasks.yml
 #   3. Checks the online status of the system by pinging 8.8.8.8.
-#   4. If all cache retrieval methods fail and the system is offline, it raises a failure message.
-#   5. If the system is online, it runs the model component-provided tasks.
+#   4. If required files are missing, the system is offline, and valid install
+#      inputs are unavailable, it raises a failure message.
+#   5. If the system is online, or if valid install_inputs are available,
+#      it runs the model component-provided tasks.
 #   6. Performs a final check for required files.
 ###################################################################################################
 - name: "Install Model Component: {{ mc_name }}"
@@ -29,10 +33,19 @@
       ansible.builtin.set_fact:
         firewheel_cache_files: "{{ (required_files | default([])) + (install_inputs | default([])) }}"
 
+    - name: Determine whether this model component has required file markers
+      ansible.builtin.set_fact:
+        firewheel_has_required_files: "{{ (required_files | default([]) | length) > 0 }}"
+
+    - name: Determine whether this model component has cacheable files
+      ansible.builtin.set_fact:
+        firewheel_has_cache_files: "{{ (firewheel_cache_files | length) > 0 }}"
+
     - name: Checking for required files
       ansible.builtin.include_role:
         name: firewheel
         tasks_from: check_and_end.yml
+      when: firewheel_has_required_files | bool
 
     - name: Create all cache destination directories
       ansible.builtin.file:
@@ -41,34 +54,62 @@
         mode: "0755"
       loop: "{{ firewheel_cache_files }}"
 
+    - name: Determine configured cache mechanisms
+      ansible.builtin.set_fact:
+        firewheel_has_git_cache: "{{ git_servers is defined and git_servers | length > 0 }}"
+        firewheel_has_s3_cache: "{{ s3_endpoints is defined and s3_endpoints | length > 0 }}"
+        firewheel_has_url_cache: "{{ file_servers is defined and file_servers | length > 0 }}"
+
     - name: Checking git cache
       ansible.builtin.include_role:
         name: firewheel
         tasks_from: git.yml
+      when:
+        - firewheel_has_git_cache | bool
+        - firewheel_has_cache_files | bool
+
+    - name: Checking for required files after Git cache
+      ansible.builtin.include_role:
+        name: firewheel
+        tasks_from: check_and_end.yml
+      when:
+        - firewheel_has_git_cache | bool
+        - firewheel_has_required_files | bool
+        - firewheel_has_cache_files | bool
 
     - name: Checking s3 cache
       ansible.builtin.include_role:
         name: firewheel
         tasks_from: s3.yml
       when:
-        - (git_clone_result is not defined) or (git_clone_result is failed)
+        - firewheel_has_s3_cache | bool
+        - firewheel_has_cache_files | bool
+
+    - name: Checking for required files after S3 cache
+      ansible.builtin.include_role:
+        name: firewheel
+        tasks_from: check_and_end.yml
+      when:
+        - firewheel_has_s3_cache | bool
+        - firewheel_has_required_files | bool
+        - firewheel_has_cache_files | bool
 
     - name: Checking URL cache
       ansible.builtin.include_role:
         name: firewheel
         tasks_from: url.yml
       when:
-        - (git_clone_result is not defined) or (git_clone_result is failed)
-        - (s3_download_result is not defined) or (s3_download_result is failed)
+        - firewheel_has_url_cache | bool
+        - firewheel_has_cache_files | bool
 
-    - name: Checking for required files
+    - name: Checking for required files after URL cache
       ansible.builtin.include_role:
         name: firewheel
         tasks_from: check_and_end.yml
-      when: |
-        (git_clone_result is defined and git_clone_result is succeeded) or
-        (s3_download_result is defined and s3_download_result is succeeded) or
-        (url_download_result is defined and url_download_result is succeeded)
+      when:
+        - firewheel_has_url_cache | bool
+        - firewheel_has_required_files | bool
+        - firewheel_has_cache_files | bool
 
     - name: Check if user is online
       ansible.builtin.command: ping -c 1 8.8.8.8
@@ -108,21 +149,24 @@
           manually place the required install inputs, or rerun on an online system.
       when:
         - (ping_result.rc | default(0)) != 0
-        - not all_install_inputs_valid | default(false)
+        - not (all_install_inputs_valid | default(false) | bool)
 
-    # If we don't have any cached files and are online
-    # then we need to run the MC Install tasks
+    # If required files are still missing, run the MC install tasks when either:
+    #   - the system appears to be online, or
+    #   - all declared install_inputs are available and valid.
     - name: "Include tasks (if needed) for: {{ mc_name }}"
       ansible.builtin.include_tasks: "{{ tasks_path }}"
       when: >-
         ((ping_result.rc | default(1)) == 0) or
-        (all_install_inputs_valid | default(false))
+        (all_install_inputs_valid | default(false) | bool)
 
     - name: Checking for required files
       ansible.builtin.include_role:
         name: firewheel
         tasks_from: check_and_end.yml
 
-    - name: Fail if any cached file destination still does not exist
+    - name: Fail if model component installation did not complete
       ansible.builtin.fail:
-        msg: "Failed to correctly install this model component!"
+        msg: >-
+          Failed to correctly install this model component. The INSTALL tasks
+          completed, but the final required_files check did not pass.

--- a/src/firewheel/control/ansible_playbooks/main.yml
+++ b/src/firewheel/control/ansible_playbooks/main.yml
@@ -5,7 +5,7 @@
 #   This Ansible playbook is designed to install extra dependencies for a model component
 #   such as file retrieval or data processing. It does this by first checking if the necessary
 #   files are available via a cache mechanism, including Git, S3, and a standard file server
-#   (via a URL). If a cache is not available, than it provides a naive check for online access
+#   (via a URL). If a cache is not available, then it provides a naive check for online access
 #   and, if needed executes the tasks that are provided in the model component
 #   ``INSTALL/tasks.yml`` file.
 #
@@ -25,17 +25,21 @@
       ansible.builtin.include_vars:
         file: "{{ vars_path }}"
 
+    - name: Build list of files that may be retrieved from cache
+      ansible.builtin.set_fact:
+        firewheel_cache_files: "{{ (required_files | default([])) + (install_inputs | default([])) }}"
+
     - name: Checking for required files
       ansible.builtin.include_role:
         name: firewheel
         tasks_from: check_and_end.yml
 
-    - name: Create all destination directories
+    - name: Create all cache destination directories
       ansible.builtin.file:
         path: "{{ item.destination | dirname }}"
         state: directory
         mode: "0755"
-      loop: "{{ required_files }}"
+      loop: "{{ firewheel_cache_files }}"
 
     - name: Checking git cache
       ansible.builtin.include_role:
@@ -72,16 +76,47 @@
       changed_when: false
       ignore_errors: true
 
+    - name: Initialize install input availability status
+      ansible.builtin.set_fact:
+        all_install_inputs_valid: "{{ (install_inputs | default([]) | length) > 0 }}"
+
+    - name: Inspect install inputs
+      ansible.builtin.stat:
+        path: "{{ item.destination }}"
+        checksum_algorithm: "{{ item.checksum_algorithm | default(item.checksum_algo | default('sha1')) }}"
+        get_checksum: true
+      register: install_inputs_check
+      loop: "{{ install_inputs | default([]) }}"
+      when: install_inputs | default([]) | length > 0
+
+    - name: Mark install inputs invalid if any are missing or checksum-invalid
+      ansible.builtin.set_fact:
+        all_install_inputs_valid: false
+      loop: "{{ install_inputs_check.results | default([]) }}"
+      when: >-
+        (not item.stat.exists) or
+        (
+          item.item.checksum is defined and
+          item.stat.checksum != item.item.checksum
+        )
+
     - name: Final failure message if all attempts fail
       ansible.builtin.fail:
-        msg: "All cache file methods have failed and system does not appear to be online. Please provide valid cache information."
-      when: (ping_result.rc | default(0)) != 0
+        msg: >-
+          Required files are not installed, the system does not appear to be online,
+          and valid install inputs are not available. Provide valid cache information,
+          manually place the required install inputs, or rerun on an online system.
+      when:
+        - (ping_result.rc | default(0)) != 0
+        - not all_install_inputs_valid | default(false)
 
     # If we don't have any cached files and are online
     # then we need to run the MC Install tasks
     - name: "Include tasks (if needed) for: {{ mc_name }}"
       ansible.builtin.include_tasks: "{{ tasks_path }}"
-      when: (ping_result.rc | default(1)) == 0
+      when: >-
+        ((ping_result.rc | default(1)) == 0) or
+        (all_install_inputs_valid | default(false))
 
     - name: Checking for required files
       ansible.builtin.include_role:

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/check_and_end.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/check_and_end.yml
@@ -16,7 +16,7 @@
     checksum_algorithm: "{{ item.checksum_algorithm | default(item.checksum_algo | default('sha1')) }}"
     get_checksum: true
   register: required_files_check
-  loop: "{{ required_files }}"
+  loop: "{{ required_files | default([]) }}"
 
 - name: Verifying checksums for required files (if needed)
   ansible.builtin.set_fact:
@@ -25,7 +25,7 @@
     - item.stat.exists
     - item.item.checksum is defined
     - item.stat.checksum != item.item.checksum
-  loop: "{{ required_files_check.results }}"
+  loop: "{{ required_files_check.results | default([]) }}"
   loop_control:
     index_var: index
 
@@ -34,7 +34,7 @@
     all_files_valid: false
   when:
     - not required_files_check.results[index].stat.exists
-  loop: "{{ required_files }}"
+  loop: "{{ required_files | default([]) }}"
   loop_control:
     index_var: index
 
@@ -42,7 +42,7 @@
   ansible.builtin.file:
     path: "{{ install_flag }}"
     state: touch
-    mode: "660"
+    mode: "0660"
   when: all_files_valid
 
 - name: Exit successfully if there are no issues with required files

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/git.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/git.yml
@@ -4,6 +4,11 @@
 # If you are using an access token, you can specify it in the `server_url`.
 # For example: https://<token>@github.com/user/repo.git
 # The user will need to provide all relevant information.
+# Note:
+#   The user-facing FIREWHEEL configuration uses the nested structure shown
+#   above. model_component_install.py flattens that structure before passing
+#   git_servers to this Ansible role.
+#
 # An example configuration is shown below:
 #
 # git_servers:

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/git_clone_loop.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/git_clone_loop.yml
@@ -33,15 +33,15 @@
     GIT_LFS_SKIP_SMUDGE: "1"
   register: git_clone_result
 
-- name: "Identfying files in {{ firewheel_repo_path }}"
+- name: "Identifying files in {{ firewheel_repo_path }}"
   ansible.builtin.stat:
-    path: "{{ ansible_remote_tmp }}/git/{{ item.source if item.source is defined else mc_name + '/'+ item.destination | basename }}"
+    path: "{{ ansible_remote_tmp }}/git/{{ item.source if item.source is defined else mc_name + '/' + (item.destination | basename) }}"
   loop: "{{ firewheel_cache_files | default(required_files) }}"
   register: file_check_results
 
 - name: LFS pull cached files
   ansible.builtin.shell:
-    cmd: "git lfs pull --include={{ item.source if item.source is defined else mc_name + '/'+ item.destination | basename }}"
+    cmd: "git lfs pull --include={{ item.source if item.source is defined else mc_name + '/' + (item.destination | basename) }}"
     chdir: "{{ ansible_remote_tmp }}/git"
   loop: "{{ firewheel_cache_files | default(required_files) }}"
   when: "item in file_check_results.results | selectattr('stat.exists', 'equalto', True) | map(attribute='item') | list"
@@ -49,7 +49,7 @@
 
 - name: Move each pulled file into place
   ansible.builtin.copy:
-    src: "{{ ansible_remote_tmp }}/git/{{ item.source if item.source is defined else mc_name + '/' + item.destination | basename }}"
+    src: "{{ ansible_remote_tmp }}/git/{{ item.source if item.source is defined else mc_name + '/' + (item.destination | basename) }}"
     dest: "{{ item.destination }}"
     mode: "0660"
   loop: "{{ firewheel_cache_files | default(required_files) }}"

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/git_clone_loop.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/git_clone_loop.yml
@@ -36,14 +36,14 @@
 - name: "Identfying files in {{ firewheel_repo_path }}"
   ansible.builtin.stat:
     path: "{{ ansible_remote_tmp }}/git/{{ item.source if item.source is defined else mc_name + '/'+ item.destination | basename }}"
-  loop: "{{ required_files }}"
+  loop: "{{ firewheel_cache_files | default(required_files) }}"
   register: file_check_results
 
-- name: LFS pull required files
+- name: LFS pull cached files
   ansible.builtin.shell:
     cmd: "git lfs pull --include={{ item.source if item.source is defined else mc_name + '/'+ item.destination | basename }}"
     chdir: "{{ ansible_remote_tmp }}/git"
-  loop: "{{ required_files }}"
+  loop: "{{ firewheel_cache_files | default(required_files) }}"
   when: "item in file_check_results.results | selectattr('stat.exists', 'equalto', True) | map(attribute='item') | list"
   register: pull_results
 
@@ -52,7 +52,7 @@
     src: "{{ ansible_remote_tmp }}/git/{{ item.source if item.source is defined else mc_name + '/' + item.destination | basename }}"
     dest: "{{ item.destination }}"
     mode: "0660"
-  loop: "{{ required_files }}"
+  loop: "{{ firewheel_cache_files | default(required_files) }}"
   when: "item in file_check_results.results | selectattr('stat.exists', 'equalto', True) | map(attribute='item') | list"
   ignore_errors: true
   register: move_results

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/s3.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/s3.yml
@@ -1,8 +1,13 @@
 ---
 ###################################################################################################
-# This playbook will loop through all values in the `required_files` variable
-# and collected those files from an S3 instance.
+# This playbook will loop through configured S3 endpoints and collect
+# cacheable files from S3.
 # The user will need to provide all relevant information.
+# Note:
+#   The user-facing FIREWHEEL configuration uses the nested structure shown
+#   above. model_component_install.py flattens that structure before passing
+#   s3_endpoints to this Ansible role.
+#
 # An example configuration is shown below:
 #
 # s3_endpoints:

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/s3_pull_loop.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/s3_pull_loop.yml
@@ -30,7 +30,7 @@
         aws_access_key: "{{ firewheel_aws_access_key_id }}"
         aws_secret_key: "{{ firewheel_aws_secret_access_key }}"
         endpoint_url: "{{ firewheel_s3_endpoint }}"
-      loop: "{{ required_files }}"
+      loop: "{{ firewheel_cache_files | default(required_files) }}"
       register: s3_download_result
       ignore_errors: true
   rescue:

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/s3_pull_loop.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/s3_pull_loop.yml
@@ -1,7 +1,7 @@
 ---
 ###################################################################################################
-# This playbook will loop through all values in the `required_files` variable
-# and collected those files from an S3 instance.
+# This playbook will loop through all cacheable files and collect those files
+# from an S3 instance.
 # The user will need to provide all relevant information.
 # An example configuration is shown below:
 #
@@ -24,7 +24,7 @@
     - name: "Attempt to download cached files from {{ firewheel_s3_bucket }}"
       amazon.aws.s3_object:
         bucket: "{{ firewheel_s3_bucket }}"
-        object: "{{ item.source if item.source is defined else mc_name + '/' + item.destination | basename }}"
+        object: "{{ item.source if item.source is defined else mc_name + '/' + (item.destination | basename) }}"
         dest: "{{ item.destination }}"
         mode: get
         aws_access_key: "{{ firewheel_aws_access_key_id }}"

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/url.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/url.yml
@@ -3,9 +3,14 @@
 # This playbook will collect cached files from a given URL.
 # It uses https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html.
 #
-# If you are using an username or password token, you can specify it in the URL
+# If you are using a username or password token, you can specify it in the URL
 # For example: https://user:password@server.com/url/cache/path/file.txt
 # The user will need to provide all relevant information.
+# Note:
+#   The user-facing FIREWHEEL configuration uses the nested structure shown
+#   above. model_component_install.py flattens that structure before passing
+#   file_servers to this Ansible role.
+#
 # An example configuration is shown below:
 #
 # file_servers:

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/url_pull_loop.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/url_pull_loop.yml
@@ -3,7 +3,7 @@
 # This playbook will collect cached files from a given URL.
 # It uses https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html.
 #
-# If you are using an username or password token, you can specify it in the URL
+# If you are using a username or password token, you can specify it in the URL
 # For example: https://user:password@server.com/url/cache/path/file.txt
 # The user will need to provide all relevant information.
 # An example configuration is shown below:
@@ -27,7 +27,17 @@
   block:
     - name: "Attempting to download cached files from: {{ firewheel_url }}"
       ansible.builtin.get_url:
-        url: "{{ firewheel_url }}/{{ firewheel_cache_path }}/{{ item.source if item.source is defined else mc_name + '/' + item.destination | basename }}"
+        url: >-
+          {{
+            firewheel_url.rstrip('/') ~
+            (
+              '/' ~ firewheel_cache_path.strip('/')
+              if firewheel_cache_path | default('') | length > 0
+              else ''
+            ) ~
+            '/' ~
+            (item.source if item.source is defined else mc_name + '/' + (item.destination | basename))
+          }}
         dest: "{{ item.destination }}"
         mode: "0660"
         use_proxy: "{{ firewheel_use_proxy }}"

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/url_pull_loop.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/url_pull_loop.yml
@@ -32,7 +32,7 @@
         mode: "0660"
         use_proxy: "{{ firewheel_use_proxy }}"
         validate_certs: "{{ firewheel_validate_certs }}"
-      loop: "{{ required_files }}"
+      loop: "{{ firewheel_cache_files | default(required_files) }}"
       register: url_download_result
       ignore_errors: true
 

--- a/src/firewheel/control/model_component_install.py
+++ b/src/firewheel/control/model_component_install.py
@@ -217,8 +217,8 @@ class ModelComponentInstall:
         file_servers = []
         for server in config["ansible"].get("file_servers", []):
             url = server["url"]
-            use_proxy = server["use_proxy"]
-            validate_certs = server["validate_certs"]
+            use_proxy = server.get("use_proxy", True)
+            validate_certs = server.get("validate_certs", True)
 
             for cache_path in server["cache_paths"]:
                 cache_info = {


### PR DESCRIPTION
## Description
This PR adds support for `install_inputs` in model component Ansible INSTALL workflows.

`install_inputs` are cacheable files that are needed by `INSTALL/tasks.yml` but are not themselves final installation markers. This allows a model component to retrieve an archive, installer, dataset, or other intermediate artifact from a configured cache and then process it into the final files listed in `required_files`.

The install framework now:

- builds a combined cache retrieval list from `required_files` and `install_inputs`;
- continues to use `required_files` as the source of truth for installation completion;
- attempts only configured cache mechanisms;
- checks for completed `required_files` after each configured cache mechanism;
- allows `tasks.yml` to run on offline systems when all declared `install_inputs` are present and valid;
- preserves existing behavior for model components that only use `required_files`.

For example, a model component can now declare a cached input archive:

```yaml
install_inputs:
  - destination: "{{ mc_dir }}/artifacts/example-data.tgz"
    checksum_algorithm: "sha256"
    checksum: "..."

required_files:
  - destination: "{{ mc_dir }}/vm_resources/example-data/metadata.json"
```

The archive can be retrieved from cache, `tasks.yml` can extract it, and installation is only considered complete after the final `required_files` exist.

### Motivation and context ###
Some model component installs require intermediate artifacts that must be transformed, unpacked, or otherwise processed before the final installed state exists. Previously, the cache mechanism primarily operated on `required_files`, which made it awkward to support offline installs where the cached file is an input to installation rather than the final output.

This change separates the concepts of:

- `install_inputs`: cacheable inputs consumed by `tasks.yml`;
- `required_files`: final installed outputs used to determine whether installation is complete.

This enables more robust offline installation workflows without overloading the meaning of `required_files`.

The PR also includes related documentation improvements and minor wording/grammar fixes in the model component INSTALL documentation.

## Type of Change ##
- New feature
- Documentation update

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://sandialabs.github.io/firewheel/developer/contributing.html).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] A human has performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code ~~with the functional test suite~~ manually, and it passed.